### PR TITLE
Add judges management and profile details

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -18,6 +18,7 @@ import NewsDetail from "@/pages/news-detail";
 import Branches from "@/pages/branches";
 import BranchDetails from "@/pages/branch-details";
 import PastChampions from "@/pages/past-champions";
+import JudgesPage from "@/pages/judges";
 import AdminTournamentResults from "@/pages/admin-tournament-results";
 import AdminTournaments from "@/pages/admin-tournaments";
 import ExcelTournamentDemo from "@/pages/excel-tournament-demo";
@@ -51,6 +52,7 @@ function Router() {
       <Route path="/branches" component={Branches} />
       <Route path="/branches/:id" component={BranchDetails} />
       <Route path="/past-champions" component={PastChampions} />
+      <Route path="/judges" component={JudgesPage} />
       <Route path="/news/:id" component={NewsDetail} />
       <Route path="/news" component={News} />
       <Route path="/about" component={AboutPage} />

--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -54,6 +54,7 @@ export default function Navigation() {
         },
         { href: "/branches", label: "Салбар холбоод" },
         { href: "/national-team", label: "Үндэсний шигшээ" },
+        { href: "/judges", label: "Шүүгчид" },
         { href: "/past-champions", label: "Үе үеийн аваргууд" },
       ],
     },

--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -76,10 +76,15 @@ export default function AdminDashboard() {
     enabled: selectedTab === 'federation-members'
   });
 
+  const { data: judges, isLoading: judgesLoading } = useQuery({
+    queryKey: ['/api/admin/judges'],
+    enabled: selectedTab === 'judges'
+  });
+
   // Load all users for player selection dropdown
   const { data: allUsers } = useQuery({
     queryKey: ['/api/admin/users'],
-    enabled: selectedTab === 'teams' && (isCreateDialogOpen || !!editingItem)
+    enabled: (selectedTab === 'teams' || selectedTab === 'judges') && (isCreateDialogOpen || !!editingItem)
   });
 
   const { data: news, isLoading: newsLoading } = useQuery({
@@ -660,6 +665,53 @@ export default function AdminDashboard() {
     );
   };
 
+  const renderJudgesTab = () => {
+    return (
+      <div className="space-y-4">
+        <div className="flex justify-between items-center gap-4">
+          <h2 className="text-2xl font-bold">Шүүгчид</h2>
+          <Button onClick={openCreateDialog}>
+            <Plus className="w-4 h-4 mr-2" />
+            Шүүгч нэмэх
+          </Button>
+        </div>
+
+        {judgesLoading ? (
+          <div>Ачааллаж байна...</div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Нэр</TableHead>
+                <TableHead>Төрөл</TableHead>
+                <TableHead>Зураг</TableHead>
+                <TableHead>Үйлдэл</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {judges && Array.isArray(judges) && judges.map((judge: any) => (
+                <TableRow key={judge.id}>
+                  <TableCell>{judge.firstName} {judge.lastName}</TableCell>
+                  <TableCell>{judge.judgeType === 'international' ? 'Олон улсын' : 'Дотоодын'}</TableCell>
+                  <TableCell>
+                    {judge.imageUrl && (
+                      <img src={judge.imageUrl} alt={judge.firstName} className="w-10 h-10 rounded-full" />
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <Button size="sm" variant="destructive" onClick={() => handleDelete(judge.id)}>
+                      <Trash2 className="w-4 h-4" />
+                    </Button>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+    );
+  };
+
   const renderSlidersTab = () => (
     <div className="space-y-4">
       <div className="flex justify-between items-center">
@@ -1064,6 +1116,64 @@ export default function AdminDashboard() {
                 value={formData.imageUrl || ''}
                 onChange={(e) => setFormData({ ...formData, imageUrl: e.target.value })}
               />
+            </div>
+          </>
+        );
+
+      case 'judges':
+        return (
+          <>
+            <div>
+              <Label htmlFor="userId">Хэрэглэгч</Label>
+              <Select onValueChange={(userId) => {
+                const user = allUsers?.find((u: any) => u.id === userId);
+                setFormData({ ...formData, userId, firstName: user?.firstName, lastName: user?.lastName });
+              }}>
+                <SelectTrigger id="userId">
+                  <SelectValue placeholder="Хэрэглэгч сонгох" />
+                </SelectTrigger>
+                <SelectContent>
+                  {allUsers?.map((u: any) => (
+                    <SelectItem key={u.id} value={u.id}>{u.firstName} {u.lastName}</SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <div>
+              <Label htmlFor="firstName">Нэр</Label>
+              <Input
+                id="firstName"
+                value={formData.firstName || ''}
+                onChange={(e) => setFormData({ ...formData, firstName: e.target.value })}
+              />
+            </div>
+            <div>
+              <Label htmlFor="lastName">Овог</Label>
+              <Input
+                id="lastName"
+                value={formData.lastName || ''}
+                onChange={(e) => setFormData({ ...formData, lastName: e.target.value })}
+              />
+            </div>
+            <div>
+              <Label htmlFor="imageUrl">Зураг URL</Label>
+              <Input
+                id="imageUrl"
+                value={formData.imageUrl || ''}
+                onChange={(e) => setFormData({ ...formData, imageUrl: e.target.value })}
+              />
+            </div>
+            <div>
+              <Label htmlFor="judgeType">Төрөл</Label>
+              <Select value={formData.judgeType || ''} onValueChange={(v) => setFormData({ ...formData, judgeType: v })}>
+                <SelectTrigger id="judgeType">
+                  <SelectValue placeholder="Сонгох" />
+                </SelectTrigger>
+                <SelectContent>
+                  <SelectItem value="domestic">Дотоодын шүүгч</SelectItem>
+                  <SelectItem value="international">Олон улсын шүүгч</SelectItem>
+                </SelectContent>
+              </Select>
             </div>
           </>
         );
@@ -1856,6 +1966,10 @@ export default function AdminDashboard() {
             <UserPlus className="w-4 h-4" />
             Холбооны гишүүд
           </TabsTrigger>
+          <TabsTrigger value="judges" className="flex items-center gap-2">
+            <Shield className="w-4 h-4" />
+            Шүүгчид
+          </TabsTrigger>
           <TabsTrigger value="news" className="flex items-center gap-2">
             <Newspaper className="w-4 h-4" />
             Мэдээ
@@ -2298,6 +2412,18 @@ export default function AdminDashboard() {
             </CardHeader>
             <CardContent>
               {renderFederationMembersTab()}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="judges">
+          <Card>
+            <CardHeader>
+              <CardTitle>Шүүгчдийн удирдлага</CardTitle>
+              <CardDescription>Шүүгчийг нэмэх, устгах</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {renderJudgesTab()}
             </CardContent>
           </Card>
         </TabsContent>

--- a/client/src/pages/judges.tsx
+++ b/client/src/pages/judges.tsx
@@ -1,0 +1,79 @@
+import { useState } from "react";
+import { useQuery } from "@tanstack/react-query";
+import Navigation from "@/components/navigation";
+import PageWithLoading from "@/components/PageWithLoading";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { Card, CardContent } from "@/components/ui/card";
+import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+
+interface Judge {
+  id: string;
+  firstName: string;
+  lastName: string;
+  imageUrl?: string;
+  judgeType: string;
+}
+
+export default function JudgesPage() {
+  const [tab, setTab] = useState("domestic");
+
+  const { data: judges = [] } = useQuery<Judge[]>({
+    queryKey: ["/api/judges", tab],
+    queryFn: async () => {
+      const res = await fetch(`/api/judges?type=${tab}`);
+      return res.json();
+    }
+  });
+
+  return (
+    <PageWithLoading>
+      <Navigation />
+      <div className="main-bg">
+        <div className="container mx-auto px-4 py-8">
+          <h1 className="text-4xl font-bold text-white mb-6 text-center">Шүүгчид</h1>
+          <Tabs value={tab} onValueChange={setTab} className="w-full">
+            <TabsList className="grid w-full grid-cols-2 mb-6 bg-gray-800 border-gray-700">
+              <TabsTrigger value="domestic" className="data-[state=active]:bg-green-600 data-[state=active]:text-white">Дотоодын шүүгчид</TabsTrigger>
+              <TabsTrigger value="international" className="data-[state=active]:bg-green-600 data-[state=active]:text-white">Олон улсын шүүгчид</TabsTrigger>
+            </TabsList>
+            <TabsContent value={"domestic"}>
+              <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+                {judges.map(judge => (
+                  <Card key={judge.id} className="bg-gray-800 text-white">
+                    <CardContent className="flex items-center gap-4 p-4">
+                      <Avatar className="w-16 h-16">
+                        <AvatarImage src={judge.imageUrl} alt={judge.firstName} />
+                        <AvatarFallback>{judge.firstName[0]}{judge.lastName[0]}</AvatarFallback>
+                      </Avatar>
+                      <div>
+                        <div className="font-semibold">{judge.firstName} {judge.lastName}</div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </TabsContent>
+            <TabsContent value={"international"}>
+              <div className="grid gap-4 sm:grid-cols-2 md:grid-cols-3">
+                {judges.map(judge => (
+                  <Card key={judge.id} className="bg-gray-800 text-white">
+                    <CardContent className="flex items-center gap-4 p-4">
+                      <Avatar className="w-16 h-16">
+                        <AvatarImage src={judge.imageUrl} alt={judge.firstName} />
+                        <AvatarFallback>{judge.firstName[0]}{judge.lastName[0]}</AvatarFallback>
+                      </Avatar>
+                      <div>
+                        <div className="font-semibold">{judge.firstName} {judge.lastName}</div>
+                      </div>
+                    </CardContent>
+                  </Card>
+                ))}
+              </div>
+            </TabsContent>
+          </Tabs>
+        </div>
+      </div>
+    </PageWithLoading>
+  );
+}
+

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -16,6 +16,7 @@ import {
   sponsors,
   branches,
   federationMembers,
+  judges,
   pastChampions,
   tournamentTeams,
   tournamentTeamPlayers,
@@ -52,6 +53,8 @@ import {
   type InsertBranch,
   type FederationMember,
   type InsertFederationMember,
+  type Judge,
+  type InsertJudge,
   type TournamentTeam,
   type InsertTournamentTeam,
   type TournamentTeamPlayer,
@@ -181,6 +184,12 @@ export interface IStorage {
   createFederationMember(member: InsertFederationMember): Promise<FederationMember>;
   updateFederationMember(id: string, member: Partial<InsertFederationMember>): Promise<FederationMember | undefined>;
   deleteFederationMember(id: string): Promise<boolean>;
+
+  // Judge operations
+  getAllJudges(type?: string): Promise<Judge[]>;
+  createJudge(judge: InsertJudge): Promise<Judge>;
+  deleteJudge(id: string): Promise<boolean>;
+  getJudgeByUserId(userId: string): Promise<Judge | undefined>;
 
   // Player tournament and match operations
   getPlayerTournamentRegistrations(playerId: string): Promise<any[]>;
@@ -1082,6 +1091,33 @@ export class DatabaseStorage implements IStorage {
   async deleteFederationMember(id: string): Promise<boolean> {
     const result = await db.delete(federationMembers).where(eq(federationMembers.id, id));
     return (result.rowCount || 0) > 0;
+  }
+
+  // Judge operations
+  async getAllJudges(type?: string): Promise<Judge[]> {
+    if (type) {
+      return await db.select().from(judges).where(eq(judges.judgeType, type as any));
+    }
+    return await db.select().from(judges);
+  }
+
+  async createJudge(judgeData: InsertJudge): Promise<Judge> {
+    const { randomUUID } = await import('crypto');
+    const [judge] = await db
+      .insert(judges)
+      .values({ id: randomUUID(), ...judgeData })
+      .returning();
+    return judge;
+  }
+
+  async deleteJudge(id: string): Promise<boolean> {
+    const result = await db.delete(judges).where(eq(judges.id, id));
+    return (result.rowCount || 0) > 0;
+  }
+
+  async getJudgeByUserId(userId: string): Promise<Judge | undefined> {
+    const [judge] = await db.select().from(judges).where(eq(judges.userId, userId));
+    return judge;
   }
 
   // Membership operations

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -360,6 +360,20 @@ export const federationMembers = pgTable("federation_members", {
   createdAt: timestamp("created_at").defaultNow(),
 });
 
+// Judge type enum
+export const judgeTypeEnum = pgEnum("judge_type", ["domestic", "international"]);
+
+// Judges table
+export const judges = pgTable("judges", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  userId: varchar("user_id").references(() => users.id),
+  firstName: varchar("first_name").notNull(),
+  lastName: varchar("last_name").notNull(),
+  imageUrl: varchar("image_url"),
+  judgeType: judgeTypeEnum("judge_type").notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
 // Past champions table
 export const pastChampions = pgTable("past_champions", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
@@ -496,6 +510,11 @@ export const insertFederationMemberSchema = createInsertSchema(federationMembers
   createdAt: true,
 });
 
+export const insertJudgeSchema = createInsertSchema(judges).omit({
+  id: true,
+  createdAt: true,
+});
+
 export const insertChampionSchema = createInsertSchema(pastChampions).omit({
   id: true,
   createdAt: true,
@@ -546,6 +565,8 @@ export type InsertBranch = z.infer<typeof insertBranchSchema>;
 export type Branch = typeof branches.$inferSelect;
 export type InsertFederationMember = z.infer<typeof insertFederationMemberSchema>;
 export type FederationMember = typeof federationMembers.$inferSelect;
+export type InsertJudge = z.infer<typeof insertJudgeSchema>;
+export type Judge = typeof judges.$inferSelect;
 export type InsertChampion = z.infer<typeof insertChampionSchema>;
 export type Champion = typeof pastChampions.$inferSelect;
 export type TournamentParticipant = typeof tournamentParticipants.$inferSelect;


### PR DESCRIPTION
## Summary
- add judges database schema and CRUD routes
- expose judges page and admin management interface
- expand profile page with judge/player statuses and personal info

## Testing
- `npm run check` *(fails: Property 'navigate' does not exist on type 'RouterObject', plus other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_689dbc0aa9e083219ead56cbb80eaf32