### PR TITLE
feat: replace knockout bracket UI

### DIFF
--- a/client/src/components/KnockoutBracket.tsx
+++ b/client/src/components/KnockoutBracket.tsx
@@ -1,181 +1,124 @@
-import { useState } from "react";
-import { Card, CardContent } from "@/components/ui/card";
-import { Badge } from "@/components/ui/badge";
-import { Trophy, Medal, Award } from "lucide-react";
+import React, { useState } from "react";
+import "./knockout.css";
+
+interface Player {
+  id: string;
+  name: string;
+}
 
 interface BracketMatch {
   id: string;
-  round: string;
-  player1?: { id: string; name: string };
-  player2?: { id: string; name: string };
+  round: number | string;
+  roundName?: string;
+  player1?: Player;
+  player2?: Player;
+  player1Score?: string;
+  player2Score?: string;
   score?: string;
-  winner?: { id: string; name: string };
-  position: { x: number; y: number };
+  winner?: Player;
+  position?: { x: number; y: number };
 }
 
 interface KnockoutBracketProps {
   matches: BracketMatch[];
   onPlayerClick?: (playerId: string) => void;
-  isViewOnly?: boolean;
 }
 
-export function KnockoutBracket({ 
-  matches, 
-  onPlayerClick, 
-  isViewOnly = true 
-}: KnockoutBracketProps) {
-  // Group matches by round
-  const matchesByRound: Record<string, BracketMatch[]> = {};
-  matches.forEach(match => {
-    if (!matchesByRound[match.round]) {
-      matchesByRound[match.round] = [];
-    }
-    matchesByRound[match.round].push(match);
+const roundClassNames = ["one", "two", "three", "four", "five", "six"]; // support up to 6 rounds
+
+function getRoundNumber(match: BracketMatch): number {
+  if (typeof match.round === "number") return match.round;
+  const map: Record<string, number> = {
+    "Финал": 1,
+    "Хагас финал": 2,
+    "Дөрөвийн финал": 3,
+    "1/8 финал": 4,
+    "1/16 финал": 5,
+    "1/32 финал": 6,
+  };
+  return map[match.round as string] ?? 99;
+}
+
+export function KnockoutBracket({ matches, onPlayerClick }: KnockoutBracketProps) {
+  const [darkTheme, setDarkTheme] = useState(true);
+
+  const handlePlayerClick = (id?: string) => {
+    if (id && onPlayerClick) onPlayerClick(id);
+  };
+
+  // Group matches by round number
+  const roundGroups = new Map<number, BracketMatch[]>();
+  matches.forEach((match) => {
+    const roundNum = getRoundNumber(match);
+    if (!roundGroups.has(roundNum)) roundGroups.set(roundNum, []);
+    roundGroups.get(roundNum)!.push(match);
   });
 
-  // Define round order and display names
-  const roundOrder = ['round16', 'quarterfinal', 'semifinal', 'final'];
-  const roundDisplayNames: Record<string, string> = {
-    'round16': '1/8 финал',
-    'quarterfinal': 'Хорь дөрвөн',
-    'semifinal': 'Хагас финал',
-    'final': 'Финал'
-  };
-
-  const getRoundIcon = (round: string) => {
-    switch (round) {
-      case 'final':
-        return <Trophy className="w-4 h-4 text-yellow-600" />;
-      case 'semifinal':
-        return <Medal className="w-4 h-4 text-gray-600" />;
-      case 'quarterfinal':
-        return <Award className="w-4 h-4 text-orange-600" />;
-      default:
-        return <Award className="w-4 h-4 text-blue-600" />;
-    }
-  };
-
-  const handlePlayerClick = (playerId?: string) => {
-    if (playerId && onPlayerClick) {
-      onPlayerClick(playerId);
-    }
-  };
-
-  const PlayerButton = ({ 
-    player, 
-    isWinner = false, 
-    className = "" 
-  }: { 
-    player?: { id: string; name: string }; 
-    isWinner?: boolean;
-    className?: string;
-  }) => {
-    if (!player) {
-      return (
-        <div className={`p-2 text-center text-gray-400 border border-dashed border-gray-300 rounded ${className}`}>
-          TBD
-        </div>
-      );
-    }
-
-    return (
-      <button
-        onClick={() => handlePlayerClick(player.id)}
-        className={`p-2 text-left border rounded transition-colors hover:bg-gray-50 ${
-          isWinner 
-            ? 'border-green-500 bg-green-50 font-semibold' 
-            : 'border-gray-300'
-        } ${className}`}
-      >
-        <div className="flex items-center justify-between">
-          <span className="text-sm">{player.name}</span>
-          {isWinner && (
-            <Badge variant="outline" className="text-xs bg-green-100 text-green-800">
-              Ялагч
-            </Badge>
-          )}
-        </div>
-      </button>
-    );
-  };
-
-  if (matches.length === 0) {
-    return (
-      <div className="text-center py-8 text-gray-500">
-        <Trophy className="w-12 h-12 mx-auto mb-2 text-gray-300" />
-        <p>Шоронтох тулаан байхгүй байна</p>
-      </div>
-    );
-  }
+  const rounds = Array.from(roundGroups.keys()).sort((a, b) => a - b);
 
   return (
-    <div className="space-y-8">
-      {roundOrder.map(round => {
-        const roundMatches = matchesByRound[round];
-        if (!roundMatches || roundMatches.length === 0) return null;
-
-        return (
-          <div key={round} className="space-y-4">
-            <div className="flex items-center gap-2 mb-4">
-              {getRoundIcon(round)}
-              <h3 className="text-lg font-semibold">
-                {roundDisplayNames[round] || round}
-              </h3>
-              <Badge variant="outline" className="text-xs">
-                {roundMatches.length} тоглолт
-              </Badge>
-            </div>
-
-            <div className="grid gap-4 md:grid-cols-2 lg:grid-cols-3">
-              {roundMatches.map((match) => (
-                <Card key={match.id} className="hover:shadow-md transition-shadow">
-                  <CardContent className="p-4">
-                    <div className="space-y-3">
-                      <div className="flex items-center justify-between">
-                        <Badge variant="outline" className="text-xs">
-                          Тоглолт #{match.id.slice(-4)}
-                        </Badge>
-                        {match.score && (
-                          <span className="text-sm font-mono text-gray-600">
-                            {match.score}
-                          </span>
-                        )}
-                      </div>
-
-                      <div className="space-y-2">
-                        <PlayerButton
-                          player={match.player1}
-                          isWinner={match.winner?.id === match.player1?.id}
-                        />
-                        
-                        <div className="text-center text-gray-400 text-xs">
-                          VS
-                        </div>
-                        
-                        <PlayerButton
-                          player={match.player2}
-                          isWinner={match.winner?.id === match.player2?.id}
-                        />
-                      </div>
-
-                      {match.winner && (
-                        <div className="pt-2 border-t">
-                          <div className="flex items-center gap-2 text-sm text-green-600">
-                            <Trophy className="w-3 h-3" />
-                            <span className="font-medium">
-                              Ялагч: {match.winner.name}
-                            </span>
-                          </div>
-                        </div>
-                      )}
+    <div className={`knockout theme ${darkTheme ? "theme-dark-trendy" : ""}`}>
+      <div className="bracket">
+        {rounds.map((round, idx) => {
+          const columnMatches = roundGroups.get(round)!;
+          const columnClass = roundClassNames[idx] || "";
+          return (
+            <div className={`column ${columnClass}`} key={round}>
+              {columnMatches.map((match) => {
+                const [score1, score2] = match.score
+                  ? match.score.split("-").map((s) => s.trim())
+                  : [match.player1Score || "", match.player2Score || ""];
+                const winnerClass = match.winner
+                  ? match.winner.id === match.player1?.id
+                    ? "winner-top"
+                    : match.winner.id === match.player2?.id
+                    ? "winner-bottom"
+                    : ""
+                  : "";
+                return (
+                  <div key={match.id} className={`match ${winnerClass}`}>
+                    <div
+                      className="match-top team"
+                      onClick={() => handlePlayerClick(match.player1?.id)}
+                    >
+                      <span className="image"></span>
+                      <span className="seed"></span>
+                      <span className="name">{match.player1?.name || "TBD"}</span>
+                      <span className="score">{score1 || "-"}</span>
                     </div>
-                  </CardContent>
-                </Card>
-              ))}
+                    <div
+                      className="match-bottom team"
+                      onClick={() => handlePlayerClick(match.player2?.id)}
+                    >
+                      <span className="image"></span>
+                      <span className="seed"></span>
+                      <span className="name">{match.player2?.name || "TBD"}</span>
+                      <span className="score">{score2 || "-"}</span>
+                    </div>
+                    <div className="match-lines">
+                      <div className="line one"></div>
+                      <div className="line two"></div>
+                    </div>
+                    <div className="match-lines alt">
+                      <div className="line one"></div>
+                    </div>
+                  </div>
+                );
+              })}
             </div>
-          </div>
-        );
-      })}
+          );
+        })}
+      </div>
+      <div className="theme-switcher">
+        <h2>Select a theme</h2>
+        <button
+          id="theme-dark-trendy"
+          onClick={() => setDarkTheme((prev) => !prev)}
+        >
+          Dark Trendy
+        </button>
+      </div>
     </div>
   );
 }
+

--- a/client/src/components/knockout.css
+++ b/client/src/components/knockout.css
@@ -1,0 +1,323 @@
+@import url("https://fonts.googleapis.com/css?family=Source+Sans+Pro:400,600,700");
+html {
+  height: 100%;
+  width: 100%;
+}
+
+body {
+  font-family: "source sans pro", sans-serif;
+  height: 100%;
+  width: 100%;
+}
+
+.theme {
+  height: 100%;
+  width: 100%;
+  position: absolute;
+}
+
+.bracket {
+  padding: 40px;
+  margin: 5px;
+}
+
+.bracket {
+  display: flex;
+  flex-direction: row;
+  position: relative;
+}
+
+.column {
+  display: flex;
+  flex-direction: column;
+  min-height: 100%;
+  justify-content: space-around;
+  align-content: center;
+}
+
+.match {
+  position: relative;
+  display: flex;
+  flex-direction: column;
+  min-width: 240px;
+  max-width: 240px;
+  height: 62px;
+  margin: 12px 24px 12px 0;
+}
+.match .match-top {
+  border-radius: 2px 2px 0 0;
+}
+.match .match-bottom {
+  border-radius: 0 0 2px 2px;
+}
+.match .team {
+  display: flex;
+  align-items: center;
+  width: 100%;
+  height: 100%;
+  border: 1px solid black;
+  position: relative;
+}
+.match .team span {
+  padding-left: 8px;
+}
+.match .team span:last-child {
+  padding-right: 8px;
+}
+.match .team .score {
+  margin-left: auto;
+}
+.match .team:first-child {
+  margin-bottom: -1px;
+}
+
+.match-lines {
+  display: block;
+  position: absolute;
+  top: 50%;
+  bottom: 0;
+  margin-top: 0px;
+  right: -1px;
+}
+.match-lines .line {
+  background: red;
+  position: absolute;
+}
+.match-lines .line.one {
+  height: 1px;
+  width: 12px;
+}
+.match-lines .line.two {
+  height: 44px;
+  width: 1px;
+  left: 11px;
+}
+.match-lines.alt {
+  left: -12px;
+}
+
+.match:nth-child(even) .match-lines .line.two {
+  transform: translate(0, -100%);
+}
+
+.column:first-child .match-lines.alt {
+  display: none;
+}
+
+.column:last-child .match-lines {
+  display: none;
+}
+.column:last-child .match-lines.alt {
+  display: block;
+}
+
+.column:nth-child(2) .match-lines .line.two {
+  height: 88px;
+}
+
+.column:nth-child(3) .match-lines .line.two {
+  height: 175px;
+}
+
+.column:nth-child(4) .match-lines .line.two {
+  height: 262px;
+}
+
+.column:nth-child(5) .match-lines .line.two {
+  height: 349px;
+}
+
+.theme-light {
+  background: #f9fafd;
+  border-color: #e6eaf7;
+}
+.theme-light .match-lines .line {
+  background: #dadfe3;
+}
+.theme-light .team {
+  background: #fff;
+  border-color: #dadfe3;
+  color: #708392;
+}
+.theme-light .winner-top .match-top,
+.theme-light .winner-bottom .match-bottom {
+  background: #fff;
+  color: #272f36;
+  border-color: #dadfe3;
+  z-index: 1;
+}
+.theme-light .match .seed {
+  color: #9fafbf;
+}
+.theme-light .match .score {
+  color: #9fafbf;
+}
+.theme-light .match .seed {
+  font-size: 12px;
+  min-width: 10px;
+}
+.theme-light .match .score {
+  font-size: 14px;
+}
+
+.theme-dark {
+  background: #0e1217;
+  border-color: #040607;
+}
+.theme-dark .match-lines .line {
+  background: #36404e;
+}
+.theme-dark .team {
+  background: #182026;
+  border-color: #232c36;
+  color: #6b798c;
+}
+.theme-dark .winner-top .match-top,
+.theme-dark .winner-bottom .match-bottom {
+  background: #232c36;
+  color: #e3e8ef;
+  border-color: #36404e;
+  z-index: 1;
+}
+.theme-dark .winner-top .match-top .score,
+.theme-dark .winner-bottom .match-bottom .score {
+  color: #03d9ce;
+}
+.theme-dark .match .seed {
+  font-size: 12px;
+  min-width: 10px;
+}
+.theme-dark .match .score {
+  font-size: 14px;
+}
+
+.theme-dark-trendy {
+  background: #2b5876;
+  background: -webkit-linear-gradient(to right, #171721, #122b29);
+  background: linear-gradient(to right, #171721, #122b29);
+  border-color: #040607;
+}
+.theme-dark-trendy .match-lines .line {
+  background: #36404e;
+}
+.theme-dark-trendy .team {
+  background: rgba(50, 54, 65, 0.4);
+  color: #6b798c;
+  border: 2px solid transparent;
+}
+.theme-dark-trendy .team:first-child {
+  margin-bottom: 2px;
+}
+.theme-dark-trendy .team:last-child {
+  margin-top: 2px;
+}
+.theme-dark-trendy .winner-top .match-top,
+.theme-dark-trendy .winner-bottom .match-bottom {
+  background: #323641;
+  color: #e3e8ef;
+  z-index: 1;
+}
+.theme-dark-trendy .winner-top .match-top .score,
+.theme-dark-trendy .winner-bottom .match-bottom .score {
+  color: #03d9ce;
+}
+.theme-dark-trendy .match {
+  margin-right: 48px;
+}
+.theme-dark-trendy .match .team .name {
+  text-transform: uppercase;
+  font-size: 14px;
+  letter-spacing: 0.5px;
+}
+.theme-dark-trendy .match .seed {
+  display: none;
+}
+.theme-dark-trendy .match .match-top {
+  border-radius: 0;
+}
+.theme-dark-trendy .match .match-bottom {
+  border-radius: 0;
+}
+.theme-dark-trendy .match-lines {
+  opacity: 0.75;
+  right: -12px;
+}
+.theme-dark-trendy .match-lines .line {
+  background: #03d9ce;
+}
+.theme-dark-trendy .match-lines.alt {
+  left: -24px;
+}
+.theme-dark-trendy .team {
+  overflow: hidden;
+}
+.theme-dark-trendy .score:before {
+  opacity: 0.25;
+  position: absolute;
+  z-index: 1;
+  content: "";
+  display: block;
+  background: black;
+  min-height: 50px;
+  min-width: 70px;
+  transform: translate(-12px, 0) rotate(25deg);
+}
+
+.disable-image .image,
+.disable-seed .seed,
+.disable-name .name,
+.disable-score .score {
+  display: none !important;
+}
+
+.disable-borders {
+  border-width: 0px !important;
+}
+.disable-borders .team {
+  border-width: 0px !important;
+}
+
+.disable-seperator .match-top {
+  border-bottom: 0px !important;
+}
+.disable-seperator .match-bottom {
+  border-top: 0px !important;
+}
+.disable-seperator .team:first-child {
+  margin-bottom: 0px;
+}
+
+.theme-switcher {
+  position: absolute;
+  top: 20px;
+  right: 20px;
+  padding: 24px;
+  border: 1px solid #c0cfdd;
+  background: #6b798c;
+}
+.theme-switcher h2 {
+  color: #e1e8ef;
+  text-transform: uppercase;
+  font-size: 12px;
+  margin: 0 0 12px 0;
+}
+.theme-switcher button {
+  line-height: 1em;
+  font-size: 14px;
+  font-weight: 500;
+  padding: 10px 16px;
+  border-radius: 2px;
+  border: 1px solid #ccc;
+  cursor: pointer;
+  background: #6b798c;
+  color: #ccc;
+  border: 1px solid #eee;
+}
+
+.theme-light .theme-switcher #theme-light,
+.theme-dark .theme-switcher #theme-dark,
+.theme-dark-trendy .theme-switcher #theme-dark-trendy,
+.theme-none .theme-switcher #theme-none {
+  background: #505b69;
+  border-color: #4a5461;
+}


### PR DESCRIPTION
## Summary
- replace knockout UI with bracket layout component built in TypeScript
- add knockout.css styling and theme switcher

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: TS errors in unrelated files)


------
https://chatgpt.com/codex/tasks/task_e_689f13c604e483218ef3f3d820aa3d2a