### PR TITLE
Add tournament full info page with tabbed sections

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -27,6 +27,7 @@ import AdminTournamentGenerator from "@/pages/admin-tournament-generator";
 import TournamentLanding from "@/pages/tournament-landing";
 import TournamentPage from "@/pages/tournament-page";
 import TournamentResults from "@/pages/tournament-results";
+import TournamentFullInfo from "@/pages/tournament-full-info";
 import Profile from "@/pages/profile";
 import PlayerProfilePage from "@/pages/player-profile";
 import AdminDashboard from "@/pages/admin-dashboard";
@@ -44,6 +45,7 @@ function Router() {
       <Route path="/tournament-landing" component={TournamentLanding} />
       <Route path="/tournament/:id" component={TournamentPage} />
       <Route path="/tournament/:id/results" component={TournamentResults} />
+      <Route path="/tournament/:id/full" component={TournamentFullInfo} />
       <Route path="/player/:id" component={PlayerProfilePage} />
       <Route path="/tournaments" component={Tournaments} />
       <Route path="/clubs" component={Clubs} />


### PR DESCRIPTION
## Summary
- add route and page for displaying full tournament information
- include tabbed sections for overview, group stage, knockout bracket, participants, album, and details

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_689f242a187c8321861fd8167f1b40d3