### PR TITLE
Add tournament full info page with tabbed sections

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -27,6 +27,7 @@ import AdminTournamentGenerator from "@/pages/admin-tournament-generator";
 import TournamentLanding from "@/pages/tournament-landing";
 import TournamentPage from "@/pages/tournament-page";
 import TournamentResults from "@/pages/tournament-results";
+import TournamentFullInfo from "@/pages/tournament-full-info";
 import Profile from "@/pages/profile";
 import PlayerProfilePage from "@/pages/player-profile";
 import AdminDashboard from "@/pages/admin-dashboard";
@@ -44,6 +45,7 @@ function Router() {
       <Route path="/tournament-landing" component={TournamentLanding} />
       <Route path="/tournament/:id" component={TournamentPage} />
       <Route path="/tournament/:id/results" component={TournamentResults} />
+      <Route path="/tournament/:id/full" component={TournamentFullInfo} />
       <Route path="/player/:id" component={PlayerProfilePage} />
       <Route path="/tournaments" component={Tournaments} />
       <Route path="/clubs" component={Clubs} />

--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -13,7 +13,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { useToast } from "@/hooks/use-toast";
-import { Pencil, Trash2, Plus, Users, Shield, Building, Trophy, Calendar, Newspaper, Images, TrendingUp, Upload, Link as LinkIcon, ArrowLeft, Settings, UserPlus, Play, Zap, X, Crown } from "lucide-react";
+import { Pencil, Trash2, Plus, Users, Shield, Building, Trophy, Calendar, Newspaper, Images, TrendingUp, Upload, Link as LinkIcon, ArrowLeft, Settings, UserPlus, Play, Zap, X, Crown, FileText } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import AdminStatsDashboard from "@/components/admin-stats-dashboard";
@@ -183,8 +183,13 @@ export default function AdminDashboard() {
       return;
     }
     if (action === 'manage-league') {
-      // Navigate to league management page  
+      // Navigate to league management page
       setLocation(`/admin/league/${tournamentId}/manage`);
+      return;
+    }
+    if (action === 'results') {
+      // Navigate to tournament results entry page
+      setLocation(`/admin/tournament/${tournamentId}/results`);
       return;
     }
     
@@ -1992,6 +1997,10 @@ export default function AdminDashboard() {
                                   </Button>
                                 </DropdownMenuTrigger>
                                 <DropdownMenuContent align="end" className="w-48">
+                                  <DropdownMenuItem onClick={() => handleTournamentManagement(tournament.id, 'results')}>
+                                    <FileText className="w-4 h-4 mr-2" />
+                                    Үр дүн оруулах
+                                  </DropdownMenuItem>
                                   <DropdownMenuItem onClick={() => handleTournamentManagement(tournament.id, 'manage-tournament')}>
                                     <Settings className="w-4 h-4 mr-2" />
                                     Удирдлагын самбар нээх

--- a/client/src/pages/tournaments.tsx
+++ b/client/src/pages/tournaments.tsx
@@ -300,9 +300,9 @@ function TournamentCard({ tournament }: { tournament: TournamentData }) {
   };
 
   return (
-    <div 
+    <div
       className="relative overflow-hidden cursor-pointer hover:shadow-2xl transition-shadow duration-300 rounded-xl mb-8"
-      onClick={() => setLocation(`/tournament/${tournament.id}`)}
+      onClick={() => setLocation(`/tournament/${tournament.id}/full`)}
     >
       <div className="relative h-64 lg:h-80">
         {/* Background Image */}


### PR DESCRIPTION
## Summary
- add route and page for displaying full tournament information
- include tabbed sections for overview, group stage, knockout bracket, participants, album, and details
- link tournaments list to full info page and ensure admin dropdown points to tournament-specific results entry

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: TypeScript errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_689f242a187c8321861fd8167f1b40d3