### PR TITLE
Enable registration on tournament full page and edit tournaments via generator

### DIFF
--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -228,8 +228,13 @@ export default function AdminDashboard() {
   };
 
   const openEditDialog = (item: any) => {
+    if (selectedTab === 'tournaments') {
+      setLocation(`/admin/generator?id=${item.id}`);
+      return;
+    }
+
     setEditingItem(item);
-    
+
     // Format dates for HTML date inputs (YYYY-MM-DD format)
     const formattedItem = { ...item };
     if (item.startDate) {
@@ -256,12 +261,12 @@ export default function AdminDashboard() {
         formattedItem.dateOfBirth = dob.toISOString().split('T')[0];
       }
     }
-    
+
     // Extract player IDs for teams
     if (selectedTab === 'teams' && item.players && Array.isArray(item.players)) {
       formattedItem.playerIds = item.players.map((player: any) => player.playerId);
     }
-    
+
     setFormData(formattedItem);
   };
 


### PR DESCRIPTION
## Summary
- enable user registration from tournament full info page with proper feedback
- redirect tournament edit action to generator for full form editing
- allow generator page to load and update existing tournaments via query param
- prefill existing tournament dates when editing so all saved values appear

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check` (fails: client/src/pages/player-profile.tsx(402,14): error TS18046: 'achievements' is of type 'unknown'. and other TS errors)


------
https://chatgpt.com/codex/tasks/task_e_689f2ff047f88321962a9122d5c0fcf7