### PR TITLE
fix: load tournament data when editing

### DIFF
--- a/client/src/pages/admin-tournament-generator.tsx
+++ b/client/src/pages/admin-tournament-generator.tsx
@@ -57,9 +57,10 @@ export default function AdminTournamentGenerator() {
   const { user, isAuthenticated, isLoading } = useAuth() as any;
   const { toast } = useToast();
   const queryClient = useQueryClient();
-  const [location, setLocation] = useLocation();
+  const [, setLocation] = useLocation();
 
-  const params = new URLSearchParams(location.split('?')[1] || '');
+  // Parse query parameters from the current URL to determine if we're editing
+  const params = new URLSearchParams(window.location.search);
   const editingId = params.get('id');
   const isEditing = !!editingId;
 


### PR DESCRIPTION
## Summary
- parse query parameters from `window.location.search`
- prefill admin tournament generator form when editing

## Testing
- `npm run check` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a055aad7bc8321b8f218dbd995eda9