### PR TITLE
Implement structured age categories for tournaments

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -74,16 +74,24 @@ async function validateTournamentEligibility(
     }
     if (cat.gender && cat.gender !== user.gender)
       throw new Error("Хүйс тохирохгүй");
-    const ageStr = String(cat.age || "");
-    const nums = ageStr.match(/\d+/g)?.map(Number) || [];
+
     let minAgeCat: number | undefined;
     let maxAgeCat: number | undefined;
-    if (nums.length === 1) {
-      if (/хүртэл/i.test(ageStr)) maxAgeCat = nums[0];
-      else minAgeCat = nums[0];
-    } else if (nums.length >= 2) {
-      [minAgeCat, maxAgeCat] = nums;
+
+    if (cat.minAge !== undefined || cat.maxAge !== undefined) {
+      if (typeof cat.minAge === "number") minAgeCat = cat.minAge;
+      if (typeof cat.maxAge === "number") maxAgeCat = cat.maxAge;
+    } else {
+      const ageStr = String(cat.age || "");
+      const nums = ageStr.match(/\d+/g)?.map(Number) || [];
+      if (nums.length === 1) {
+        if (/хүртэл/i.test(ageStr)) maxAgeCat = nums[0];
+        else minAgeCat = nums[0];
+      } else if (nums.length >= 2) {
+        [minAgeCat, maxAgeCat] = nums;
+      }
     }
+
     if (minAgeCat !== undefined && age < minAgeCat)
       throw new Error("Нас шаардлага хангахгүй байна");
     if (maxAgeCat !== undefined && age > maxAgeCat)


### PR DESCRIPTION
## Summary
- Replace free-text age categories with structured min/max age and gender fields in admin tournament generator
- Parse and display structured categories across tournament views
- Validate participant registration against min/max age boundaries on the server

## Testing
- `npm run check` *(fails: 'achievements' is of type 'unknown', Property 'navigate' does not exist on type 'RouterObject', Parameter 'a' implicitly has an 'any' type, Parameter 'b' implicitly has an 'any' type, Parameter 'tournament' implicitly has an 'any' type, TS2769 in server/storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68a192640b288321be81e60d1d95a16a