### PR TITLE
Ensure admin mutations include credentials for slider and sponsor creation

### DIFF
--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -105,10 +105,9 @@ export default function AdminDashboard() {
   // Generic mutations
   const createMutation = useMutation({
     mutationFn: async ({ endpoint, data }: { endpoint: string; data: any }) => {
-      return fetch(endpoint, {
+      return apiRequest(endpoint, {
         method: 'POST',
-        body: JSON.stringify(data),
-        headers: { 'Content-Type': 'application/json' }
+        body: JSON.stringify(data)
       });
     },
     onSuccess: () => {
@@ -124,10 +123,9 @@ export default function AdminDashboard() {
 
   const updateMutation = useMutation({
     mutationFn: async ({ endpoint, data }: { endpoint: string; data: any }) => {
-      return fetch(endpoint, {
+      return apiRequest(endpoint, {
         method: 'PUT',
-        body: JSON.stringify(data),
-        headers: { 'Content-Type': 'application/json' }
+        body: JSON.stringify(data)
       });
     },
     onSuccess: () => {
@@ -143,7 +141,7 @@ export default function AdminDashboard() {
 
   const deleteMutation = useMutation({
     mutationFn: async (endpoint: string) => {
-      return fetch(endpoint, { method: 'DELETE' });
+      return apiRequest(endpoint, { method: 'DELETE' });
     },
     onSuccess: () => {
       toast({ title: "Амжилттай устгагдлаа" });


### PR DESCRIPTION
## Summary
- Use `apiRequest` for admin create/update/delete mutations to include credentials

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: many TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a45f2d2e248321b17dc124c95c3cba