### PR TITLE
Allow file uploads for federation member images

### DIFF
--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -984,12 +984,70 @@ export default function AdminDashboard() {
               />
             </div>
             <div>
-              <Label htmlFor="imageUrl">Зураг URL</Label>
-              <Input
-                id="imageUrl"
-                value={formData.imageUrl || ''}
-                onChange={(e) => setFormData({ ...formData, imageUrl: e.target.value })}
-              />
+              <Label className="flex items-center gap-2">
+                <Upload className="w-4 h-4" />
+                Зураг оруулах
+              </Label>
+              <ObjectUploader
+                maxNumberOfFiles={1}
+                maxFileSize={5242880} // 5MB
+                onGetUploadParameters={async () => {
+                  const response = await fetch('/api/objects/upload', {
+                    method: 'POST',
+                    headers: {
+                      'Content-Type': 'application/json'
+                    }
+                  });
+                  const data = await response.json();
+                  return {
+                    method: 'PUT' as const,
+                    url: data.uploadURL
+                  };
+                }}
+                onComplete={async (result) => {
+                  if (result.successful && result.successful.length > 0) {
+                    const uploadedFileUrl = result.successful[0].uploadURL;
+
+                    try {
+                      const response = await fetch('/api/objects/finalize', {
+                        method: 'PUT',
+                        headers: {
+                          'Content-Type': 'application/json'
+                        },
+                        body: JSON.stringify({
+                          fileURL: uploadedFileUrl,
+                          isPublic: true
+                        })
+                      });
+                      const data = await response.json();
+
+                      setFormData({ ...formData, imageUrl: data.objectPath });
+                      toast({
+                        title: "Амжилттай",
+                        description: "Зураг амжилттай хуулагдлаа"
+                      });
+                    } catch (error) {
+                      console.error('Error setting image ACL:', error);
+                      setFormData({ ...formData, imageUrl: uploadedFileUrl });
+                      toast({
+                        title: "Анхааруулга",
+                        description: "Зураг хуулагдсан боловч зураг харагдахгүй байж магад"
+                      });
+                    }
+                  }
+                }}
+                buttonClassName="w-full"
+              >
+                <div className="flex items-center gap-2">
+                  <Upload className="w-4 h-4" />
+                  <span>Зураг файл сонгох</span>
+                </div>
+              </ObjectUploader>
+              {formData.imageUrl && (
+                <div className="mt-2">
+                  <p className="text-sm text-gray-600">Зураг хуулагдсан: {formData.imageUrl}</p>
+                </div>
+              )}
             </div>
           </>
         );


### PR DESCRIPTION
## Summary
- Replace federation member image URL input with an uploader so admins can attach image files

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4687802dc8321b99fb5f06e167178