### PR TITLE
style: unify background and button styles

### DIFF
--- a/client/src/components/PageWithLoading.tsx
+++ b/client/src/components/PageWithLoading.tsx
@@ -13,7 +13,7 @@ const PageWithLoading: React.FC<PageWithLoadingProps> = ({
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gradient-to-br from-gray-900 via-gray-800 to-black flex items-center justify-center">
+      <div className="min-h-screen main-bg flex items-center justify-center">
         <div className="text-center">
           <LoadingAnimation size={120} />
           <p className="text-white text-xl mt-8 opacity-75">
@@ -24,7 +24,7 @@ const PageWithLoading: React.FC<PageWithLoadingProps> = ({
     );
   }
 
-  return <>{children}</>;
+  return <div className="min-h-screen main-bg">{children}</div>;
 };
 
 export default PageWithLoading;

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -13,7 +13,19 @@ a:hover { color: var(--link); }
 .text-muted-foreground, .text-muted { color: var(--text-secondary) !important; }
 .text-gray-400, .text-gray-500, .text-gray-600, .text-gray-700 { color: var(--text-secondary) !important; }
 .bg-secondary { background-color: var(--accent) !important; color: var(--link) !important; }
-button { color: inherit; }
+button {
+  background: linear-gradient(135deg, var(--success), var(--link));
+  color: var(--text-primary);
+  border: none;
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  cursor: pointer;
+  transition: background 0.3s ease;
+}
+
+button:hover {
+  background: linear-gradient(135deg, var(--link), var(--success));
+}
 .tabs-list button, [role="tab"] { background-color: var(--accent) !important; color: var(--link) !important; border: 1px solid var(--border) !important; }
 .tabs-list button[data-state="active"], [role="tab"][data-state="active"] { background-color: var(--link) !important; color: var(--text-primary) !important; border-color: var(--link) !important; }
 .news-card, .sponsor-card { background: var(--card) !important; border: 1px solid var(--border) !important; }
@@ -29,6 +41,13 @@ button[role="tab"][data-state="active"] { background-color: var(--link) !importa
 .secondary-tab, .tab-secondary { background-color: var(--accent) !important; color: var(--link) !important; border: 1px solid var(--border) !important; }
 .secondary-tab:hover, .tab-secondary:hover { background-color: rgba(var(--link-rgb), 0.2) !important; }
 .main-content .card, .main-content .card-content { background: var(--card) !important; border: 1px solid var(--border) !important; color: var(--text-primary) !important; }
+
+/* Global page background */
+.main-bg {
+  background-color: var(--background);
+  color: var(--text-primary);
+  min-height: 100vh;
+}
 
 /* Glowing Animated Background */
 .glow-bg {


### PR DESCRIPTION
## Summary
- add global gradient button styling for better visibility
- define and apply `.main-bg` for consistent page backgrounds
- wrap pages in `PageWithLoading` with the new background container

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c2172f488321942f785e92de2fae