### PR TITLE
Apply Noto Sans Mongolian globally

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -7,6 +7,7 @@
 body {
   background-color: var(--background);
   color: var(--text-primary);
+  font-family: 'Noto Sans Mongolian', sans-serif;
 }
 h1, h2, h3, h4, h5, h6 {
   color: var(--text-primary);

--- a/tailwind.config.ts
+++ b/tailwind.config.ts
@@ -5,6 +5,9 @@ export default {
   content: ["./client/index.html", "./client/src/**/*.{js,jsx,ts,tsx}"],
   theme: {
     extend: {
+      fontFamily: {
+        sans: ["'Noto Sans Mongolian'", "sans-serif"],
+      },
       borderRadius: {
         lg: "var(--radius)",
         md: "calc(var(--radius) - 2px)",


### PR DESCRIPTION
## Summary
- use Noto Sans Mongolian for all body text
- configure Tailwind's `sans` font family to default to Noto Sans Mongolian

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: TypeScript errors)


------
https://chatgpt.com/codex/tasks/task_e_68a571108540832199d7fe2ebac1fe13