### PR TITLE
feat: show dropdown text without hover

### DIFF
--- a/client/src/index.css
+++ b/client/src/index.css
@@ -705,8 +705,9 @@ button[role="tab"][data-state="active"] { background-color: var(--link) !importa
   position: relative;
 }
 
+/* Dropdown content is now always visible to avoid hover-only text */
 .dropdown-content {
-  display: none;
+  display: block;
   position: absolute;
   top: 110%;
   left: 0;
@@ -736,9 +737,7 @@ button[role="tab"][data-state="active"] { background-color: var(--link) !importa
   color: var(--link);
 }
 
-.dropdown:hover .dropdown-content {
-  display: block;
-}
+
 
 /* Scrollbar styling */
 ::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- Display dropdown content by default to eliminate hover-only text

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68a572da469c83219a14c57eff0ee4fd