### PR TITLE
Add coach management and extended club details

### DIFF
--- a/client/src/pages/clubs.tsx
+++ b/client/src/pages/clubs.tsx
@@ -12,7 +12,7 @@ import { Textarea } from "@/components/ui/textarea";
 import { Badge } from "@/components/ui/badge";
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { Form, FormControl, FormField, FormItem, FormLabel, FormMessage } from "@/components/ui/form";
-import { Building, Plus, Users, MapPin, Phone, Mail, Settings, User, Crown } from "lucide-react";
+import { Building, Plus, Users, MapPin, Phone, Mail, Settings, User, Crown, Clock, Link as LinkIcon, UserCog } from "lucide-react";
 import { useForm } from "react-hook-form";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { insertClubSchema } from "@shared/schema";
@@ -407,7 +407,44 @@ export default function Clubs() {
                               <span className="text-gray-600">{clubDetails.email}</span>
                             </div>
                           )}
+                          {clubDetails.schedule && (
+                            <div className="flex items-start">
+                              <Clock className="h-4 w-4 mr-2 text-mtta-green mt-0.5" />
+                              <span className="text-gray-600">{clubDetails.schedule}</span>
+                            </div>
+                          )}
+                          {clubDetails.website && (
+                            <div className="flex items-center">
+                              <LinkIcon className="h-4 w-4 mr-2 text-mtta-green" />
+                              <a href={clubDetails.website} target="_blank" rel="noopener noreferrer" className="text-blue-600">
+                                {clubDetails.website}
+                              </a>
+                            </div>
+                          )}
                         </div>
+                      </div>
+
+                      {clubDetails.trainingInfo && (
+                        <div>
+                          <h4 className="font-semibold text-gray-900 mb-2">Сургалтын мэдээлэл</h4>
+                          <p className="text-gray-600 text-sm">{clubDetails.trainingInfo}</p>
+                        </div>
+                      )}
+
+                      <div>
+                        <h4 className="font-semibold text-gray-900 mb-3">Дасгалжуулагчид ({clubDetails.coaches?.length || 0})</h4>
+                        {clubDetails.coaches && clubDetails.coaches.length > 0 ? (
+                          <div className="space-y-2 max-h-40 overflow-y-auto">
+                            {clubDetails.coaches.map((coach: any) => (
+                              <div key={coach.id} className="flex items-center space-x-2 p-2 bg-gray-50 rounded">
+                                <UserCog className="h-4 w-4 text-gray-400" />
+                                <span className="text-sm">{coach.firstName} {coach.lastName}</span>
+                              </div>
+                            ))}
+                          </div>
+                        ) : (
+                          <p className="text-gray-500 text-sm">Одоогоор дасгалжуулагч байхгүй</p>
+                        )}
                       </div>
 
                       <div>

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -14,7 +14,7 @@ import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
 import { Badge } from "@/components/ui/badge";
 import { Separator } from "@/components/ui/separator";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { AlertCircle, CheckCircle, Clock, User, Camera, MapPin, Phone, Mail, Calendar, Trophy, Target, CreditCard, Users, History, Shield } from "lucide-react";
+import { AlertCircle, CheckCircle, Clock, User, Camera, MapPin, Phone, Mail, Calendar, Trophy, Target, CreditCard, Users, History, Shield, UserCog } from "lucide-react";
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 
@@ -51,6 +51,7 @@ interface UserProfile {
   membershipAmount?: number;
   isJudge?: boolean;
   judgeType?: string;
+  isCoach?: boolean;
   playerStats?: PlayerStats;
 }
 
@@ -496,6 +497,12 @@ export default function Profile() {
                       <Badge variant="secondary" className="bg-blue-100 text-blue-800">
                         <Shield className="w-3 h-3 mr-1" />
                         Шүүгч
+                      </Badge>
+                    )}
+                    {profile?.isCoach && (
+                      <Badge variant="secondary" className="bg-green-100 text-green-800">
+                        <UserCog className="w-3 h-3 mr-1" />
+                        Дасгалжуулагч
                       </Badge>
                     )}
                   </div>

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -17,6 +17,7 @@ import {
   branches,
   federationMembers,
   judges,
+  clubCoaches,
   pastChampions,
   tournamentTeams,
   tournamentTeamPlayers,
@@ -55,6 +56,8 @@ import {
   type InsertFederationMember,
   type Judge,
   type InsertJudge,
+  type ClubCoach,
+  type InsertClubCoach,
   type TournamentTeam,
   type InsertTournamentTeam,
   type TournamentTeamPlayer,
@@ -97,6 +100,13 @@ export interface IStorage {
   createClub(club: InsertClub): Promise<Club>;
   getClubsByOwner(ownerId: string): Promise<Club[]>;
   getAllClubs(): Promise<Club[]>;
+
+  // Club coach operations
+  getClubCoachesByClub(clubId: string): Promise<any[]>;
+  getAllClubCoaches(): Promise<any[]>;
+  createClubCoach(coach: InsertClubCoach): Promise<ClubCoach>;
+  deleteClubCoach(id: string): Promise<boolean>;
+  getClubCoachByUserId(userId: string): Promise<ClubCoach | undefined>;
 
   // Branch operations
   getBranch(id: string): Promise<Branch | undefined>;
@@ -565,6 +575,53 @@ export class DatabaseStorage implements IStorage {
   async deleteClub(id: string): Promise<boolean> {
     const result = await db.delete(clubs).where(eq(clubs.id, id));
     return (result.rowCount || 0) > 0;
+  }
+
+  // Club coach operations
+  async getClubCoachesByClub(clubId: string): Promise<any[]> {
+    return await db
+      .select({
+        id: clubCoaches.id,
+        userId: clubCoaches.userId,
+        firstName: users.firstName,
+        lastName: users.lastName,
+      })
+      .from(clubCoaches)
+      .leftJoin(users, eq(clubCoaches.userId, users.id))
+      .where(eq(clubCoaches.clubId, clubId));
+  }
+
+  async getAllClubCoaches(): Promise<any[]> {
+    return await db
+      .select({
+        id: clubCoaches.id,
+        clubId: clubCoaches.clubId,
+        userId: clubCoaches.userId,
+        firstName: users.firstName,
+        lastName: users.lastName,
+        clubName: clubs.name,
+      })
+      .from(clubCoaches)
+      .leftJoin(users, eq(clubCoaches.userId, users.id))
+      .leftJoin(clubs, eq(clubCoaches.clubId, clubs.id));
+  }
+
+  async createClubCoach(data: InsertClubCoach): Promise<ClubCoach> {
+    const [coach] = await db.insert(clubCoaches).values(data).returning();
+    return coach;
+  }
+
+  async deleteClubCoach(id: string): Promise<boolean> {
+    const result = await db.delete(clubCoaches).where(eq(clubCoaches.id, id));
+    return (result.rowCount || 0) > 0;
+  }
+
+  async getClubCoachByUserId(userId: string): Promise<ClubCoach | undefined> {
+    const [coach] = await db
+      .select()
+      .from(clubCoaches)
+      .where(eq(clubCoaches.userId, userId));
+    return coach;
   }
 
   // Branch operations

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -123,6 +123,10 @@ export const clubs = pgTable("clubs", {
   email: varchar("email"),
   logoUrl: varchar("logo_url"),
   colorTheme: varchar("color_theme").default("var(--success)"),
+  schedule: text("schedule"),
+  website: varchar("website"),
+  trainingInfo: text("training_info"),
+  extraData: jsonb("extra_data"),
   createdAt: timestamp("created_at").defaultNow(),
 });
 
@@ -374,6 +378,14 @@ export const judges = pgTable("judges", {
   createdAt: timestamp("created_at").defaultNow(),
 });
 
+// Club coaches table
+export const clubCoaches = pgTable("club_coaches", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  clubId: varchar("club_id").references(() => clubs.id).notNull(),
+  userId: varchar("user_id").references(() => users.id).notNull(),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
 // Past champions table
 export const pastChampions = pgTable("past_champions", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
@@ -415,8 +427,20 @@ export const clubsRelations = relations(clubs, ({ one, many }) => ({
     references: [users.id],
   }),
   players: many(players),
+  coaches: many(clubCoaches),
   teams: many(teams),
   tournaments: many(tournaments),
+}));
+
+export const clubCoachesRelations = relations(clubCoaches, ({ one }) => ({
+  club: one(clubs, {
+    fields: [clubCoaches.clubId],
+    references: [clubs.id],
+  }),
+  user: one(users, {
+    fields: [clubCoaches.userId],
+    references: [users.id],
+  }),
 }));
 
 export const matchesRelations = relations(matches, ({ one, many }) => ({
@@ -515,6 +539,11 @@ export const insertJudgeSchema = createInsertSchema(judges).omit({
   createdAt: true,
 });
 
+export const insertClubCoachSchema = createInsertSchema(clubCoaches).omit({
+  id: true,
+  createdAt: true,
+});
+
 export const insertChampionSchema = createInsertSchema(pastChampions).omit({
   id: true,
   createdAt: true,
@@ -567,6 +596,8 @@ export type InsertFederationMember = z.infer<typeof insertFederationMemberSchema
 export type FederationMember = typeof federationMembers.$inferSelect;
 export type InsertJudge = z.infer<typeof insertJudgeSchema>;
 export type Judge = typeof judges.$inferSelect;
+export type InsertClubCoach = z.infer<typeof insertClubCoachSchema>;
+export type ClubCoach = typeof clubCoaches.$inferSelect;
 export type InsertChampion = z.infer<typeof insertChampionSchema>;
 export type Champion = typeof pastChampions.$inferSelect;
 export type TournamentParticipant = typeof tournamentParticipants.$inferSelect;


### PR DESCRIPTION
## Summary
- extend club schema with schedule, links, training info and dynamic extra fields
- introduce club coaches table with API and storage CRUD
- update admin dashboard, club page and user profile to manage/display coaches and new club fields

## Testing
- `npm run check` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a57ae7ebdc83218db4e77e1d1facd2