### PR TITLE
feat: allow manual entry for club coaches

### DIFF
--- a/client/src/components/UserAutocomplete.tsx
+++ b/client/src/components/UserAutocomplete.tsx
@@ -1,6 +1,8 @@
 import { useState, useEffect } from "react";
 import { Check, ChevronsUpDown } from "lucide-react";
 import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Checkbox } from "@/components/ui/checkbox";
 import {
   Command,
   CommandEmpty,
@@ -44,10 +46,17 @@ export function UserAutocomplete({
 }: UserAutocompleteProps) {
   const [open, setOpen] = useState(false);
   const [searchTerm, setSearchTerm] = useState("");
+  const [isCustom, setIsCustom] = useState(false);
+
+  useEffect(() => {
+    if (customNameValue && !value) {
+      setIsCustom(true);
+    }
+  }, [customNameValue, value]);
 
   const selectedUser = users.find(user => user.id === value);
-  const displayValue = selectedUser 
-    ? `${selectedUser.firstName} ${selectedUser.lastName}` 
+  const displayValue = selectedUser
+    ? `${selectedUser.firstName} ${selectedUser.lastName}`
     : customNameValue || placeholder;
 
   // Filter users based on search term
@@ -68,16 +77,7 @@ export function UserAutocomplete({
     setSearchTerm("");
   };
 
-  const handleCustomNameSelect = () => {
-    if (allowCustomName && searchTerm.trim()) {
-      onCustomNameChange?.(searchTerm.trim());
-      onSelect(null); // No user selected, using custom name
-      setOpen(false);
-      setSearchTerm("");
-    }
-  };
-
-  return (
+  const content = (
     <Popover open={open} onOpenChange={setOpen}>
       <PopoverTrigger asChild>
         <Button
@@ -92,25 +92,14 @@ export function UserAutocomplete({
       </PopoverTrigger>
       <PopoverContent className="w-full p-0">
         <Command>
-          <CommandInput 
-            placeholder="Тоглогчийн нэрээр хайх..." 
+          <CommandInput
+            placeholder="Тоглогчийн нэрээр хайх..."
             value={searchTerm}
             onValueChange={setSearchTerm}
           />
           <CommandEmpty>
             <div className="py-2 text-center text-sm">
-              {allowCustomName && searchTerm.trim() ? (
-                <Button
-                  variant="ghost"
-                  size="sm"
-                  onClick={handleCustomNameSelect}
-                  className="w-full"
-                >
-                  "{searchTerm}" гэсэн нэрийг ашиглах
-                </Button>
-              ) : (
-                "Тоглогч олдсонгүй"
-              )}
+              {"Тоглогч олдсонгүй"}
             </div>
           </CommandEmpty>
           <CommandGroup className="max-h-64 overflow-y-auto">
@@ -142,5 +131,42 @@ export function UserAutocomplete({
         </Command>
       </PopoverContent>
     </Popover>
+  );
+
+  return (
+    <div className="space-y-2">
+      {isCustom ? (
+        <Input
+          value={customNameValue}
+          onChange={(e) => {
+            onCustomNameChange?.(e.target.value);
+            onSelect(null);
+          }}
+          placeholder={placeholder}
+        />
+      ) : (
+        content
+      )}
+      {allowCustomName && (
+        <div className="flex items-center space-x-2">
+          <Checkbox
+            id="non-system-user"
+            checked={isCustom}
+            onCheckedChange={(checked) => {
+              const c = Boolean(checked);
+              setIsCustom(c);
+              if (!c) {
+                onCustomNameChange?.("");
+              } else {
+                onSelect(null);
+              }
+            }}
+          />
+          <label htmlFor="non-system-user" className="text-sm">
+            Системийн хэрэглэгч биш
+          </label>
+        </div>
+      )}
+    </div>
   );
 }

--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -674,7 +674,9 @@ export default function AdminDashboard() {
             <TableBody>
               {coaches && Array.isArray(coaches) && coaches.map((coach: any) => (
                 <TableRow key={coach.id}>
-                  <TableCell>{coach.firstName} {coach.lastName}</TableCell>
+                  <TableCell>
+                    {coach.name || `${coach.firstName || ''} ${coach.lastName || ''}`}
+                  </TableCell>
                   <TableCell>{coach.clubName}</TableCell>
                   <TableCell>
                     <Button size="sm" variant="destructive" onClick={() => handleDelete(coach.id)}>
@@ -1050,12 +1052,15 @@ export default function AdminDashboard() {
               </Select>
             </div>
             <div>
-              <Label>Хэрэглэгч</Label>
+              <Label>Хэрэглэгч эсвэл нэр</Label>
               <UserAutocomplete
                 users={allUsers || []}
                 value={formData.userId}
-                onSelect={(u) => setFormData({ ...formData, userId: u ? u.id : '' })}
+                onSelect={(u) => setFormData({ ...formData, userId: u ? u.id : '', name: '' })}
                 placeholder="Хэрэглэгч хайх..."
+                allowCustomName
+                customNameValue={formData.name || ''}
+                onCustomNameChange={(name) => setFormData({ ...formData, name, userId: '' })}
               />
             </div>
           </>

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -583,6 +583,7 @@ export class DatabaseStorage implements IStorage {
       .select({
         id: clubCoaches.id,
         userId: clubCoaches.userId,
+        name: clubCoaches.name,
         firstName: users.firstName,
         lastName: users.lastName,
       })
@@ -597,6 +598,7 @@ export class DatabaseStorage implements IStorage {
         id: clubCoaches.id,
         clubId: clubCoaches.clubId,
         userId: clubCoaches.userId,
+        name: clubCoaches.name,
         firstName: users.firstName,
         lastName: users.lastName,
         clubName: clubs.name,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -382,7 +382,8 @@ export const judges = pgTable("judges", {
 export const clubCoaches = pgTable("club_coaches", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   clubId: varchar("club_id").references(() => clubs.id).notNull(),
-  userId: varchar("user_id").references(() => users.id).notNull(),
+  userId: varchar("user_id").references(() => users.id),
+  name: varchar("name"),
   createdAt: timestamp("created_at").defaultNow(),
 });
 
@@ -542,6 +543,9 @@ export const insertJudgeSchema = createInsertSchema(judges).omit({
 export const insertClubCoachSchema = createInsertSchema(clubCoaches).omit({
   id: true,
   createdAt: true,
+}).refine(data => data.userId || data.name, {
+  message: "userId or name is required",
+  path: ["userId"],
 });
 
 export const insertChampionSchema = createInsertSchema(pastChampions).omit({


### PR DESCRIPTION
## Summary
- allow storing club coaches without user accounts by adding optional name field
- add checkbox-driven custom name support to UserAutocomplete component
- enable manual coach entry in admin dashboard and show custom names in coach list

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68a584cf81808321b062da602a97efa1