### PR TITLE
Allow non-system names for club owners and judges

### DIFF
--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -925,17 +925,24 @@ export default function AdminDashboard() {
               />
             </div>
             <div>
-              <Label htmlFor="ownerId">Клубын эзэн</Label>
-              <Select value={formData.ownerId || ''} onValueChange={(v) => setFormData({ ...formData, ownerId: v })}>
-                <SelectTrigger id="ownerId">
-                  <SelectValue placeholder="Эзэн сонгох" />
-                </SelectTrigger>
-                <SelectContent>
-                  {allUsers?.filter((u: any) => u.role === 'club_owner').map((u: any) => (
-                    <SelectItem key={u.id} value={u.id}>{u.firstName} {u.lastName}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
+              <Label>Клубын эзэн</Label>
+              <UserAutocomplete
+                users={(allUsers || []).filter((u: any) => u.role === 'club_owner')}
+                value={formData.ownerId}
+                onSelect={(u) =>
+                  setFormData({
+                    ...formData,
+                    ownerId: u ? u.id : '',
+                    ownerName: u ? '' : formData.ownerName,
+                  })
+                }
+                placeholder="Эзэн хайх..."
+                allowCustomName
+                customNameValue={formData.ownerName || ''}
+                onCustomNameChange={(name) =>
+                  setFormData({ ...formData, ownerName: name, ownerId: '' })
+                }
+              />
             </div>
             <div>
               <Label htmlFor="description">Тайлбар</Label>
@@ -1283,35 +1290,30 @@ export default function AdminDashboard() {
         return (
           <>
             <div>
-              <Label htmlFor="userId">Хэрэглэгч</Label>
-              <Select onValueChange={(userId) => {
-                const user = allUsers?.find((u: any) => u.id === userId);
-                setFormData({ ...formData, userId, firstName: user?.firstName, lastName: user?.lastName });
-              }}>
-                <SelectTrigger id="userId">
-                  <SelectValue placeholder="Хэрэглэгч сонгох" />
-                </SelectTrigger>
-                <SelectContent>
-                  {allUsers?.map((u: any) => (
-                    <SelectItem key={u.id} value={u.id}>{u.firstName} {u.lastName}</SelectItem>
-                  ))}
-                </SelectContent>
-              </Select>
-            </div>
-            <div>
-              <Label htmlFor="firstName">Нэр</Label>
-              <Input
-                id="firstName"
-                value={formData.firstName || ''}
-                onChange={(e) => setFormData({ ...formData, firstName: e.target.value })}
-              />
-            </div>
-            <div>
-              <Label htmlFor="lastName">Овог</Label>
-              <Input
-                id="lastName"
-                value={formData.lastName || ''}
-                onChange={(e) => setFormData({ ...formData, lastName: e.target.value })}
+              <Label>Хэрэглэгч эсвэл нэр</Label>
+              <UserAutocomplete
+                users={allUsers || []}
+                value={formData.userId}
+                onSelect={(u) =>
+                  setFormData({
+                    ...formData,
+                    userId: u ? u.id : '',
+                    firstName: u?.firstName || '',
+                    lastName: u?.lastName || '',
+                  })
+                }
+                placeholder="Шүүгч хайх..."
+                allowCustomName
+                customNameValue={`${formData.firstName || ''} ${formData.lastName || ''}`.trim()}
+                onCustomNameChange={(name) => {
+                  const [first, ...rest] = name.split(' ');
+                  setFormData({
+                    ...formData,
+                    userId: '',
+                    firstName: first,
+                    lastName: rest.join(' '),
+                  });
+                }}
               />
             </div>
             <div>

--- a/client/src/pages/clubs.tsx
+++ b/client/src/pages/clubs.tsx
@@ -305,7 +305,7 @@ export default function Clubs() {
                           <CardTitle className="text-lg">{club.name}</CardTitle>
                           <p className="text-sm text-gray-600 flex items-center">
                             <Crown className="h-3 w-3 mr-1" />
-                            {club.owner?.firstName} {club.owner?.lastName}
+                            {club.owner ? `${club.owner.firstName} ${club.owner.lastName}` : club.ownerName}
                           </p>
                         </div>
                       </div>
@@ -374,7 +374,7 @@ export default function Clubs() {
                         <CardTitle className="text-xl">{clubDetails.name}</CardTitle>
                         <p className="text-gray-600 flex items-center">
                           <Crown className="h-4 w-4 mr-1" />
-                          Эзэн: {clubDetails.owner?.firstName} {clubDetails.owner?.lastName}
+                          Эзэн: {clubDetails.owner ? `${clubDetails.owner.firstName} ${clubDetails.owner.lastName}` : clubDetails.ownerName}
                         </p>
                       </div>
                     </div>

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -669,7 +669,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
       if (!club) return res.status(404).json({ message: "Клуб олдсонгүй" });
       const players = await storage.getPlayersByClub(req.params.id);
       const coaches = await storage.getClubCoachesByClub(req.params.id);
-      const owner = await storage.getUser(club.ownerId);
+      const owner = club.ownerId ? await storage.getUser(club.ownerId) : null;
       res.json({ ...club, players, coaches, owner });
     } catch (e) {
       console.error("Error fetching club:", e);

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -117,7 +117,8 @@ export const clubs = pgTable("clubs", {
   id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
   name: varchar("name").notNull(),
   description: text("description"),
-  ownerId: varchar("owner_id").references(() => users.id).notNull(),
+  ownerId: varchar("owner_id").references(() => users.id),
+  ownerName: varchar("owner_name"),
   address: text("address"),
   phone: varchar("phone"),
   email: varchar("email"),
@@ -490,10 +491,15 @@ export const insertPlayerSchema = createInsertSchema(players).omit({
   winPercentage: true,
 });
 
-export const insertClubSchema = createInsertSchema(clubs).omit({
-  id: true,
-  createdAt: true,
-});
+export const insertClubSchema = createInsertSchema(clubs)
+  .omit({
+    id: true,
+    createdAt: true,
+  })
+  .refine((data) => data.ownerId || data.ownerName, {
+    message: "ownerId or ownerName is required",
+    path: ["ownerId"],
+  });
 
 export const insertTournamentSchema = createInsertSchema(tournaments).omit({
   id: true,


### PR DESCRIPTION
## Summary
- support optional ownerName for clubs and allow manual club owner entry
- enable judge selection via user lookup or free-form name
- show club owner names when no linked user exists and guard club lookup API

## Testing
- `npm test` (fails: Missing script: "test")
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68a588e0941c83218176cb8689b5d60f