### PR TITLE
feat(admin): add coach field for clubs

### DIFF
--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -945,6 +945,26 @@ export default function AdminDashboard() {
               />
             </div>
             <div>
+              <Label>Клубын багш дасгалжуулагч</Label>
+              <UserAutocomplete
+                users={allUsers || []}
+                value={formData.coachUserId}
+                onSelect={(u) =>
+                  setFormData({
+                    ...formData,
+                    coachUserId: u ? u.id : '',
+                    coachName: u ? '' : formData.coachName,
+                  })
+                }
+                placeholder="Дасгалжуулагч хайх..."
+                allowCustomName
+                customNameValue={formData.coachName || ''}
+                onCustomNameChange={(name) =>
+                  setFormData({ ...formData, coachName: name, coachUserId: '' })
+                }
+              />
+            </div>
+            <div>
               <Label htmlFor="description">Тайлбар</Label>
               <Textarea
                 id="description"


### PR DESCRIPTION
## Summary
- allow admins to input club coach using the same user search component as club owners
- handle coach data when creating or updating clubs on the backend

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: see TypeScript errors in player-profile and profile pages)*

------
https://chatgpt.com/codex/tasks/task_e_68a59104d4048321b07786d5aaa90cd8