### PR TITLE
Allow adding tournament participants without existing player ID

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -988,17 +988,20 @@ export async function registerRoutes(app: Express): Promise<Server> {
         const { tournamentId } = req.params;
         const { playerId, playerName, participationType } = req.body;
 
-        if (!playerId && !playerName)
-          return res
-            .status(400)
-            .json({ message: "playerId or playerName is required" });
         if (!participationType)
           return res
             .status(400)
             .json({ message: "participationType is required" });
 
         let finalPlayerId = playerId;
-        if (!finalPlayerId && playerName) {
+
+        // If no playerId is provided, create a basic user and player record
+        if (!finalPlayerId) {
+          if (!playerName)
+            return res
+              .status(400)
+              .json({ message: "playerName is required" });
+
           const [firstName, ...rest] = String(playerName).split(" ");
           const lastName = rest.join(" ");
           const newUser = await storage.createSimpleUser({
@@ -1016,9 +1019,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
             userId: newUser.id,
           });
           finalPlayerId = newPlayer.id;
-        }
-
-        if (playerId) {
+        } else {
           try {
             await validateTournamentEligibility(
               tournamentId,


### PR DESCRIPTION
## Summary
- create a basic user/player when adding a participant without an ID so the API no longer searches by player ID

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68a5bb448f0c832197de2e220df12704