### PR TITLE
feat: enable rich text editing for news

### DIFF
--- a/client/src/pages/news-detail.tsx
+++ b/client/src/pages/news-detail.tsx
@@ -229,12 +229,11 @@ export default function NewsDetail() {
               </CardHeader>
               
               <CardContent>
-                <div className="prose max-w-none">
-                  <p className="text-gray-700 text-lg leading-relaxed whitespace-pre-wrap">
-                    {article.content}
-                  </p>
-                </div>
-                
+                <div
+                  className="prose max-w-none text-gray-700 text-lg leading-relaxed"
+                  dangerouslySetInnerHTML={{ __html: article.content }}
+                />
+
                 <Separator className="my-8" />
                 
                 {/* Author Info and Actions */}

--- a/client/src/pages/news.tsx
+++ b/client/src/pages/news.tsx
@@ -22,6 +22,7 @@ import { ObjectUploader } from "@/components/ObjectUploader";
 import type { UploadResult } from "@uppy/core";
 import { Link } from "wouter";
 import PageWithLoading from "@/components/PageWithLoading";
+import RichTextEditor from "@/components/rich-text-editor";
 
 type CreateNewsForm = z.infer<typeof insertNewsSchema>;
 
@@ -406,10 +407,10 @@ export default function News() {
                           <FormItem>
                             <FormLabel>Дэлгэрэнгүй агуулга</FormLabel>
                             <FormControl>
-                              <Textarea 
-                                placeholder="Мэдээний дэлгэрэнгүй агуулга..." 
-                                rows={8}
-                                {...field} 
+                              <RichTextEditor
+                                content={field.value}
+                                onChange={field.onChange}
+                                placeholder="Мэдээний дэлгэрэнгүй агуулга..."
                               />
                             </FormControl>
                             <FormMessage />
@@ -543,10 +544,10 @@ export default function News() {
                           <FormItem>
                             <FormLabel>Мэдээний агуулга *</FormLabel>
                             <FormControl>
-                              <Textarea 
-                                {...field} 
+                              <RichTextEditor
+                                content={field.value}
+                                onChange={field.onChange}
                                 placeholder="Мэдээний бүрэн агуулга оруулна уу"
-                                rows={6}
                               />
                             </FormControl>
                             <FormMessage />
@@ -705,7 +706,10 @@ export default function News() {
                   </CardHeader>
                   <CardContent>
                     <p className="text-gray-600 mb-4">{article.excerpt}</p>
-                    <p className="text-gray-700 leading-relaxed mb-6">{article.content}</p>
+                    <div
+                      className="text-gray-700 leading-relaxed mb-6 prose max-w-none"
+                      dangerouslySetInnerHTML={{ __html: article.content }}
+                    />
                     
                     <div className="flex items-center justify-between">
                       <div className="flex items-center space-x-3">


### PR DESCRIPTION
## Summary
- replace news content textareas with RichTextEditor allowing inline images and formatting
- render stored rich text HTML in news listing and detail views

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Property 'firstName' does not exist on type '{}' in player-profile.tsx and other existing type errors)*

------
https://chatgpt.com/codex/tasks/task_e_68a96d9554f083219da8191b8bf04fe0