### PR TITLE
Fix news creation auth and editor

### DIFF
--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -19,6 +19,7 @@ import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@
 import AdminStatsDashboard from "@/components/admin-stats-dashboard";
 import { ObjectUploader } from "@/components/ObjectUploader";
 import { UserAutocomplete } from "@/components/UserAutocomplete";
+import RichTextEditor from "@/components/rich-text-editor";
 
 export default function AdminDashboard() {
   const [selectedTab, setSelectedTab] = useState("stats");
@@ -1563,11 +1564,10 @@ export default function AdminDashboard() {
             </div>
             <div>
               <Label htmlFor="content">Агуулга</Label>
-              <Textarea
-                id="content"
-                value={formData.content || ''}
-                onChange={(e) => setFormData({...formData, content: e.target.value})}
-                rows={5}
+              <RichTextEditor
+                content={formData.content || ''}
+                onChange={(value) => setFormData({ ...formData, content: value })}
+                placeholder="Мэдээний агуулга..."
               />
             </div>
             <div>
@@ -1641,7 +1641,11 @@ export default function AdminDashboard() {
               </ObjectUploader>
               {formData.imageUrl && (
                 <div className="mt-2">
-                  <p className="text-sm text-text-secondary">Зураг хуулагдсан: {formData.imageUrl}</p>
+                  <img
+                    src={formData.imageUrl.startsWith('/') ? `/public-objects${formData.imageUrl}` : formData.imageUrl}
+                    alt="Мэдээний зураг"
+                    className="w-32 h-24 object-cover rounded"
+                  />
                 </div>
               )}
             </div>

--- a/client/src/pages/news.tsx
+++ b/client/src/pages/news.tsx
@@ -60,7 +60,7 @@ export default function News() {
       content: "",
       excerpt: "",
       category: "news",
-      published: false,
+      published: true,
       imageUrl: "",
     },
   });

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1113,9 +1113,9 @@ export async function registerRoutes(app: Express): Promise<Server> {
   // ----------------
   // News
   // ----------------
-  app.post("/api/news", isAuthenticated, async (req: any, res) => {
+  app.post("/api/news", requireAuth, async (req: any, res) => {
     try {
-      const authorId = req.user.claims.sub;
+      const authorId = req.session.userId;
       const newsData = insertNewsSchema.parse({ ...req.body, authorId });
       const news = await storage.createNews(newsData);
       res.json(news);
@@ -1172,7 +1172,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.put("/api/news/:id/publish", isAuthenticated, async (req, res) => {
+  app.put("/api/news/:id/publish", requireAuth, async (req, res) => {
     try {
       await storage.publishNews(req.params.id);
       res.json({ message: "Мэдээ амжилттай нийтлэгдлээ" });
@@ -1182,7 +1182,7 @@ export async function registerRoutes(app: Express): Promise<Server> {
     }
   });
 
-  app.put("/api/news/:id", isAuthenticated, async (req: any, res) => {
+  app.put("/api/news/:id", requireAuth, async (req: any, res) => {
     try {
       const newsData = insertNewsSchema.partial().parse(req.body);
       if (req.body.imageUrl && req.body.imageUrl !== "")


### PR DESCRIPTION
## Summary
- switch news endpoints to session auth so posting works
- use rich text editor and image preview for admin news form
- auto-publish new articles on /news by default

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: TS errors in unrelated files)


------
https://chatgpt.com/codex/tasks/task_e_68a98a6e6e948321bd4f29c52d499c8b