### PR TITLE
Fix news creation and sync admin panel

### DIFF
--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -125,6 +125,10 @@ export default function AdminDashboard() {
     onSuccess: () => {
       toast({ title: "Амжилттай үүслээ" });
       queryClient.invalidateQueries({ queryKey: [`/api/admin/${selectedTab}`] });
+      if (selectedTab === 'news') {
+        queryClient.invalidateQueries({ queryKey: ['/api/news'] });
+        queryClient.invalidateQueries({ queryKey: ['/api/news/latest'] });
+      }
       setIsCreateDialogOpen(false);
       setFormData({});
     },
@@ -143,6 +147,10 @@ export default function AdminDashboard() {
     onSuccess: () => {
       toast({ title: "Амжилттай шинэчлэгдлээ" });
       queryClient.invalidateQueries({ queryKey: [`/api/admin/${selectedTab}`] });
+      if (selectedTab === 'news') {
+        queryClient.invalidateQueries({ queryKey: ['/api/news'] });
+        queryClient.invalidateQueries({ queryKey: ['/api/news/latest'] });
+      }
       setEditingItem(null);
       setFormData({});
     },
@@ -158,6 +166,10 @@ export default function AdminDashboard() {
     onSuccess: () => {
       toast({ title: "Амжилттай устгагдлаа" });
       queryClient.invalidateQueries({ queryKey: [`/api/admin/${selectedTab}`] });
+      if (selectedTab === 'news') {
+        queryClient.invalidateQueries({ queryKey: ['/api/news'] });
+        queryClient.invalidateQueries({ queryKey: ['/api/news/latest'] });
+      }
     },
     onError: (error: any) => {
       toast({ title: "Алдаа гарлаа", description: error.message, variant: "destructive" });
@@ -289,13 +301,13 @@ export default function AdminDashboard() {
   const openCreateDialog = () => {
     // Initialize with appropriate default values based on selected tab
     let defaultData = {};
-    
+
     if (selectedTab === 'leagues') {
       // For leagues, provide sensible default dates
       const today = new Date();
       const nextMonth = new Date(today);
       nextMonth.setMonth(today.getMonth() + 1);
-      
+
       defaultData = {
         name: '',
         description: '',
@@ -303,8 +315,18 @@ export default function AdminDashboard() {
         startDate: today.toISOString().split('T')[0],
         endDate: nextMonth.toISOString().split('T')[0]
       };
+    } else if (selectedTab === 'news') {
+      // Match /news defaults
+      defaultData = {
+        title: '',
+        content: '',
+        excerpt: '',
+        imageUrl: '',
+        category: 'news',
+        published: true
+      };
     }
-    
+
     setFormData(defaultData);
     setIsCreateDialogOpen(true);
   };

--- a/client/src/pages/news.tsx
+++ b/client/src/pages/news.tsx
@@ -24,7 +24,8 @@ import { Link } from "wouter";
 import PageWithLoading from "@/components/PageWithLoading";
 import RichTextEditor from "@/components/rich-text-editor";
 
-type CreateNewsForm = z.infer<typeof insertNewsSchema>;
+const newsFormSchema = insertNewsSchema.omit({ authorId: true });
+type CreateNewsForm = z.infer<typeof newsFormSchema>;
 
 export default function News() {
   const { user, isAuthenticated, isLoading } = useAuth();
@@ -54,7 +55,7 @@ export default function News() {
 
   // Create news form
   const form = useForm<CreateNewsForm>({
-    resolver: zodResolver(insertNewsSchema),
+    resolver: zodResolver(newsFormSchema),
     defaultValues: {
       title: "",
       content: "",
@@ -66,8 +67,8 @@ export default function News() {
   });
 
   // Create news mutation
-  const createNewsMutation = useMutation({
-    mutationFn: async (data: CreateNewsForm) => {
+  const createNewsMutation = useMutation<any, Error, CreateNewsForm & { authorId: string }>({
+    mutationFn: async (data) => {
       const response = await apiRequest("/api/news", {
         method: "POST",
         body: JSON.stringify(data),
@@ -143,8 +144,8 @@ export default function News() {
   });
 
   // Update news mutation
-  const updateNewsMutation = useMutation({
-    mutationFn: async (data: { id: string; newsData: Partial<CreateNewsForm> }) => {
+  const updateNewsMutation = useMutation<any, Error, { id: string; newsData: Partial<CreateNewsForm> & { authorId: string } }>({
+    mutationFn: async (data) => {
       const response = await apiRequest(`/api/news/${data.id}`, {
         method: "PUT",
         body: JSON.stringify(data.newsData),


### PR DESCRIPTION
## Summary
- Default admin news form to publish immediately and refresh public feeds
- Allow news form to omit authorId so posts submit correctly

## Testing
- ⚠️ `npm test` (fails: Missing script "test")
- ⚠️ `npm run check` (fails: TypeScript errors)


------
https://chatgpt.com/codex/tasks/task_e_68a98cb410f48321b70509287763871b