### PR TITLE
feat: allow image URLs in rich text editor

### DIFF
--- a/client/src/components/rich-text-editor.tsx
+++ b/client/src/components/rich-text-editor.tsx
@@ -268,6 +268,16 @@ export default function RichTextEditor({ content, onChange, placeholder, classNa
                     <span>Зураг хуулах</span>
                   </div>
                 </ObjectUploader>
+                <div className="mt-4">
+                  <Label htmlFor="imageUrlInput">Зурагны URL (заавал биш)</Label>
+                  <Input
+                    id="imageUrlInput"
+                    type="text"
+                    value={imageUrl}
+                    onChange={(e) => setImageUrl(e.target.value)}
+                    placeholder="https://example.com/image.jpg"
+                  />
+                </div>
                 {imageUrl && (
                   <div className="mt-2">
                     <div className="relative w-full h-40 overflow-hidden rounded-lg border">


### PR DESCRIPTION
## Summary
- Support inserting images via direct URL in the rich text editor

## Testing
- `npm run check` *(fails: Property 'firstName' does not exist on type '{}', etc.)*
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68a9924c844c83219ffb62af2b9a433c