### PR TITLE
fix rich text image url

### DIFF
--- a/client/src/components/rich-text-editor.tsx
+++ b/client/src/components/rich-text-editor.tsx
@@ -134,7 +134,7 @@ export default function RichTextEditor({ content, onChange, placeholder, classNa
       const { objectPath } = await response.json()
       const publicUrl = objectPath.startsWith('/')
         ? `/public-objects${objectPath}`
-        : objectPath
+        : `/public-objects/${objectPath}`
       setImageUrl(publicUrl)
     }
   }


### PR DESCRIPTION
## Summary
- ensure inserted images use /public-objects prefix so news content images render reliably

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: TS2552: Cannot find name 'navigate'; ...)*

------
https://chatgpt.com/codex/tasks/task_e_68aac6061f8083218c2ae2b8bd1953ce