### PR TITLE
fix news image preview

### DIFF
--- a/client/src/components/rich-text-editor.tsx
+++ b/client/src/components/rich-text-editor.tsx
@@ -132,9 +132,11 @@ export default function RichTextEditor({ content, onChange, placeholder, classNa
         }),
       })
       const { objectPath } = await response.json()
-      const publicUrl = objectPath.startsWith('/')
-        ? `/public-objects${objectPath}`
-        : `/public-objects/${objectPath}`
+      // Normalize returned object path and convert to public serving URL
+      const normalizedPath = objectPath
+        .replace(/^\/?objects\//, "")
+        .replace(/^\//, "")
+      const publicUrl = `/public-objects/${normalizedPath}`
       setImageUrl(publicUrl)
     }
   }

--- a/client/src/pages/news.tsx
+++ b/client/src/pages/news.tsx
@@ -346,12 +346,13 @@ export default function News() {
     if (imageUrl.startsWith('http')) return imageUrl;
     if (imageUrl.startsWith('data:')) return imageUrl; // Handle base64 data URLs
     
-    // If it's already an objects path, use it directly (served from public directory)
+    // If it's an object storage path, map it to the public-objects route
     if (imageUrl.startsWith('/objects/')) {
-      return imageUrl;
+      const path = imageUrl.replace(/^\/objects\//, '');
+      return `/public-objects/${path}`;
     }
-    
-    // For other paths
+
+    // For other absolute or relative paths ensure they're served via public-objects
     if (imageUrl.startsWith('/')) return `/public-objects${imageUrl}`;
     return `/public-objects/${imageUrl}`;
   };


### PR DESCRIPTION
## Summary
- normalize uploaded image path in RichTextEditor and map to public objects URL
- ensure news images use public-objects route for display

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: Cannot find name 'navigate', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68aac8080ebc8321bb86cab83b252226