### PR TITLE
fix: prevent form submission on file upload

### DIFF
--- a/client/src/components/ObjectUploader.tsx
+++ b/client/src/components/ObjectUploader.tsx
@@ -78,7 +78,11 @@ export function ObjectUploader({
 
   return (
     <div>
-      <Button onClick={() => setShowModal(true)} className={buttonClassName}>
+      <Button
+        type="button"
+        onClick={() => setShowModal(true)}
+        className={buttonClassName}
+      >
         {children}
       </Button>
 


### PR DESCRIPTION
## Summary
- avoid form submission when using ObjectUploader by setting button type="button"

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68aacbbe30dc8321bb85a945db803657