### PR TITLE
Fix image paths for embedded news content

### DIFF
--- a/client/src/pages/branch-details.tsx
+++ b/client/src/pages/branch-details.tsx
@@ -26,6 +26,7 @@ function getImageUrl(imageUrl?: string): string {
   ) {
     return imageUrl;
   }
+  if (imageUrl.startsWith("/public-objects/")) return imageUrl;
   if (imageUrl.startsWith("/objects/")) return imageUrl;
   if (imageUrl.startsWith("/")) return `/public-objects${imageUrl}`;
   return `/public-objects/${imageUrl}`;

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -104,8 +104,9 @@ export default function Home() {
     if (imageUrl.startsWith('data:')) {
       return imageUrl;
     }
-    
-    // If it's an object storage path (starts with /objects/), use it directly (served from public directory)
+
+    // If it's an object storage path (starts with /objects/) or already a public-objects path, use it directly
+    if (imageUrl.startsWith('/public-objects/')) return imageUrl;
     if (imageUrl.startsWith('/objects/')) {
       return imageUrl;
     }

--- a/client/src/pages/news-detail.tsx
+++ b/client/src/pages/news-detail.tsx
@@ -29,11 +29,12 @@ function LatestNewsSidebar({ currentNewsId }: { currentNewsId: string | undefine
     if (!imageUrl) return placeholderImageData;
     if (imageUrl.startsWith('http')) return imageUrl;
     if (imageUrl.startsWith('data:')) return imageUrl;
-    
+
+    if (imageUrl.startsWith('/public-objects/')) return imageUrl;
     if (imageUrl.startsWith('/objects/')) {
       return imageUrl;
     }
-    
+
     if (imageUrl.startsWith('/')) return `/public-objects${imageUrl}`;
     return `/public-objects/${imageUrl}`;
   };
@@ -224,12 +225,13 @@ export default function NewsDetail() {
     if (!imageUrl) return placeholderImageData;
     if (imageUrl.startsWith('http')) return imageUrl;
     if (imageUrl.startsWith('data:')) return imageUrl; // Handle base64 data URLs
-    
+
+    if (imageUrl.startsWith('/public-objects/')) return imageUrl;
     // If it's already an objects path, use it directly (served from public directory)
     if (imageUrl.startsWith('/objects/')) {
       return imageUrl;
     }
-    
+
     // For other paths
     if (imageUrl.startsWith('/')) return `/public-objects${imageUrl}`;
     return `/public-objects/${imageUrl}`;

--- a/client/src/pages/news.tsx
+++ b/client/src/pages/news.tsx
@@ -345,8 +345,9 @@ export default function News() {
     if (!imageUrl) return placeholderImageData;
     if (imageUrl.startsWith('http')) return imageUrl;
     if (imageUrl.startsWith('data:')) return imageUrl; // Handle base64 data URLs
-    
+
     // If it's an object storage path, map it to the public-objects route
+    if (imageUrl.startsWith('/public-objects/')) return imageUrl;
     if (imageUrl.startsWith('/objects/')) {
       const path = imageUrl.replace(/^\/objects\//, '');
       return `/public-objects/${path}`;


### PR DESCRIPTION
## Summary
- Avoid double prefixing image URLs that already include `/public-objects/`
- Apply consistent image URL handling across news pages and other sections

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check` *(fails: Cannot find name 'navigate', TypeScript errors in storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68aad2eea5688321b33be54708b53946