### PR TITLE
fix: normalize duplicate image paths

### DIFF
--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -23,6 +23,7 @@ export function getImageUrl(imageUrl: string): string {
 
   console.log("getImageUrl: Processing URL:", imageUrl);
 
+
   // Handle data URLs (base64 encoded images)
   if (imageUrl.startsWith('data:')) {
     console.log("getImageUrl: Data URL detected, returning as-is");
@@ -47,6 +48,11 @@ export function getImageUrl(imageUrl: string): string {
     console.log("getImageUrl: External URL detected, returning as-is");
     return imageUrl;
   }
+
+  // Fix duplicate path segments that may appear in stored URLs
+  imageUrl = imageUrl
+    .replace(/\/public-objects\/public-objects\//g, '/public-objects/')
+    .replace(/\/objects\/objects\//g, '/objects/');
 
   // Clean up the path - remove leading slashes and normalize
   let cleanUrl = imageUrl.replace(/^\/+/, '');


### PR DESCRIPTION
## Summary
- handle duplicate `/objects/` or `/public-objects/` segments in image URLs

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: Property 'losses' does not exist on type '{}', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68babcabe41c8321a4ec6d835c35de38