### PR TITLE
fix: show images in news content

### DIFF
--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -65,11 +65,11 @@ export function getImageUrl(imageUrl: string): string {
     return objectPath;
   }
 
-  // Handle paths that already have public-objects prefix - convert to objects
+  // Handle paths that already have public-objects prefix - serve as-is for public access
   if (cleanUrl.startsWith('public-objects/')) {
-    const objectPath = cleanUrl.replace('public-objects/', 'objects/');
-    console.log("getImageUrl: Converting public-objects to objects:", `/${objectPath}`);
-    return `/${objectPath}`;
+    const publicPath = `/${cleanUrl}`;
+    console.log("getImageUrl: Public object path:", publicPath);
+    return publicPath;
   }
 
   // For paths starting with uploads/, assume they are object storage uploads


### PR DESCRIPTION
## Summary
- fix news content image URLs to use public object paths

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68babfbad10083219061c619d3522359