### PR TITLE
Fix tournament creation request

### DIFF
--- a/client/src/pages/admin-tournament-generator.tsx
+++ b/client/src/pages/admin-tournament-generator.tsx
@@ -224,9 +224,15 @@ export default function AdminTournamentGenerator() {
       };
 
       if (isEditing && editingId) {
-        await apiRequest("PUT", `/api/admin/tournaments/${editingId}`, payload);
+        await apiRequest(`/api/admin/tournaments/${editingId}`, {
+          method: "PUT",
+          body: JSON.stringify(payload),
+        });
       } else {
-        await apiRequest("POST", "/api/tournaments", payload);
+        await apiRequest("/api/tournaments", {
+          method: "POST",
+          body: JSON.stringify(payload),
+        });
       }
     },
     onSuccess: () => {


### PR DESCRIPTION
## Summary
- fix admin tournament generator to send proper POST/PUT requests using apiRequest

## Testing
- `npm run check` *(fails: TS2322: Type 'string' is not assignable to type 'Date', etc.)*


------
https://chatgpt.com/codex/tasks/task_e_68bad14486b48321b011a8072fcfde00