### PR TITLE
feat: link national team admin page

### DIFF
--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -192,6 +192,12 @@ export default function Navigation() {
                         <span>{t('nav.admin')}</span>
                       </div>
                     </Link>
+                    <Link href="/admin/national-team">
+                      <div className="nav-link flex items-center space-x-2 px-3 py-2 cursor-pointer">
+                        <Users className="h-4 w-4" />
+                        <span>{t('nav.nationalTeam')}</span>
+                      </div>
+                    </Link>
                     <Link href="/profile">
                       <div className="nav-link flex items-center space-x-2 px-3 py-2 cursor-pointer">
                         <User className="h-4 w-4" />
@@ -378,6 +384,15 @@ export default function Navigation() {
                         >
                           <User className="h-4 w-4 mr-3" />
                           <span>{t('nav.admin')}</span>
+                        </div>
+                      </Link>
+                      <Link href="/admin/national-team">
+                        <div
+                          onClick={() => setShowMobileMenu(false)}
+                          className="flex items-center text-white p-3 rounded hover:bg-gray-700"
+                        >
+                          <Users className="h-4 w-4 mr-3" />
+                          <span>{t('nav.nationalTeam')}</span>
                         </div>
                       </Link>
                       <Link href="/admin/generator">


### PR DESCRIPTION
## Summary
- add navigation links to national team admin page for desktop and mobile

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: TypeScript errors in existing files)*

------
https://chatgpt.com/codex/tasks/task_e_68bad29486988321ba660c3c7be167e7