### PR TITLE
fix: correct drizzle configuration

### DIFF
--- a/server/db.ts
+++ b/server/db.ts
@@ -12,4 +12,4 @@ if (!process.env.DATABASE_URL) {
 }
 
 export const pool = new Pool({ connectionString: process.env.DATABASE_URL });
-export const db = drizzle({ client: pool, schema });
+export const db = drizzle(pool, { schema });


### PR DESCRIPTION
## Summary
- correct drizzle initialization for database by passing pool as first argument

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68bad8b562948321be0910edcf342bf3