### PR TITLE
Add national team management

### DIFF
--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -13,7 +13,7 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Dialog, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle, DialogTrigger } from "@/components/ui/dialog";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { useToast } from "@/hooks/use-toast";
-import { Pencil, Trash2, Plus, Users, Shield, Building, Trophy, Calendar, Newspaper, Images, TrendingUp, Upload, Link as LinkIcon, ArrowLeft, Settings, UserPlus, Play, Zap, X, Crown, FileText, UserCog, User as UserIcon } from "lucide-react";
+import { Pencil, Trash2, Plus, Users, Shield, Building, Trophy, Calendar, Newspaper, Images, TrendingUp, Upload, Link as LinkIcon, ArrowLeft, Settings, UserPlus, Play, Zap, X, Crown, FileText, UserCog, User as UserIcon, Flag } from "lucide-react";
 import { Badge } from "@/components/ui/badge";
 import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from "@/components/ui/table";
 import AdminStatsDashboard from "@/components/admin-stats-dashboard";
@@ -46,6 +46,7 @@ export default function AdminDashboard() {
   const [clubFilter, setClubFilter] = useState("");
   const [branchFilter, setBranchFilter] = useState("");
   const [memberFilter, setMemberFilter] = useState("");
+  const [nationalTeamFilter, setNationalTeamFilter] = useState("");
   const { toast } = useToast();
   const queryClient = useQueryClient();
   const [, setLocation] = useLocation();
@@ -131,14 +132,19 @@ export default function AdminDashboard() {
     enabled: selectedTab === 'branches'
   });
 
-  const { data: federationMembers, isLoading: federationMembersLoading } = useQuery({
-    queryKey: ['/api/admin/federation-members'],
-    enabled: selectedTab === 'federation-members'
-  });
+const { data: federationMembers, isLoading: federationMembersLoading } = useQuery({
+  queryKey: ['/api/admin/federation-members'],
+  enabled: selectedTab === 'federation-members'
+});
 
-  const { data: judges, isLoading: judgesLoading, refetch: judgesRefetch } = useQuery({
-    queryKey: ['/api/admin/judges'],
-    enabled: selectedTab === 'judges'
+const { data: nationalTeam, isLoading: nationalTeamLoading } = useQuery({
+  queryKey: ['/api/admin/national-team'],
+  enabled: selectedTab === 'national-team'
+});
+
+const { data: judges, isLoading: judgesLoading, refetch: judgesRefetch } = useQuery({
+  queryKey: ['/api/admin/judges'],
+  enabled: selectedTab === 'judges'
   });
 
   const { data: coaches, isLoading: coachesLoading } = useQuery({
@@ -195,6 +201,9 @@ export default function AdminDashboard() {
       if (selectedTab === 'leagues') {
         queryClient.invalidateQueries({ queryKey: ['/api/leagues'] });
       }
+      if (selectedTab === 'national-team') {
+        queryClient.invalidateQueries({ queryKey: ['/api/national-team'] });
+      }
       setIsCreateDialogOpen(false);
       setFormData({});
     },
@@ -220,6 +229,9 @@ export default function AdminDashboard() {
       if (selectedTab === 'leagues') {
         queryClient.invalidateQueries({ queryKey: ['/api/leagues'] });
       }
+      if (selectedTab === 'national-team') {
+        queryClient.invalidateQueries({ queryKey: ['/api/national-team'] });
+      }
       setEditingItem(null);
       setFormData({});
     },
@@ -241,6 +253,9 @@ export default function AdminDashboard() {
       }
       if (selectedTab === 'leagues') {
         queryClient.invalidateQueries({ queryKey: ['/api/leagues'] });
+      }
+      if (selectedTab === 'national-team') {
+        queryClient.invalidateQueries({ queryKey: ['/api/national-team'] });
       }
     },
     onError: (error: any) => {
@@ -412,6 +427,13 @@ export default function AdminDashboard() {
         activities: item.activities || "",
         imageUrl: item.imageUrl || "", // Preload imageUrl
       });
+    } else if (selectedTab === "national-team") {
+      setFormData({
+        firstName: item.firstName || "",
+        lastName: item.lastName || "",
+        age: item.age || 0,
+        imageUrl: item.imageUrl || "",
+      });
     }
     setShowDialog(true); // Show the dialog
   };
@@ -462,6 +484,13 @@ export default function AdminDashboard() {
         lastName: '',
         imageUrl: '',
         judgeType: 'domestic' // Default to domestic
+      };
+    } else if (selectedTab === 'national-team') {
+      defaultData = {
+        firstName: '',
+        lastName: '',
+        age: '',
+        imageUrl: '',
       };
     } else if (selectedTab === 'clubs') {
       // Default values for clubs, including location fields
@@ -814,6 +843,82 @@ export default function AdminDashboard() {
                         <Pencil className="w-4 h-4" />
                       </Button>
                       <Button size="sm" variant="destructive" onClick={() => handleDelete(member.id)}>
+                        <Trash2 className="w-4 h-4" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        )}
+      </div>
+    );
+  };
+
+  const renderNationalTeamTab = () => {
+    const filteredPlayers = nationalTeam && Array.isArray(nationalTeam)
+      ? nationalTeam.filter((player: any) => {
+          const searchText = nationalTeamFilter.toLowerCase();
+          return (
+            !searchText ||
+            player.firstName?.toLowerCase().includes(searchText) ||
+            player.lastName?.toLowerCase().includes(searchText)
+          );
+        })
+      : [];
+
+    return (
+      <div className="space-y-4">
+        <div className="flex flex-wrap justify-between items-center gap-4">
+          <h2 className="text-2xl font-bold">Үндэсний шигшээ</h2>
+          <div className="flex-1 max-w-sm">
+            <Input
+              placeholder="Тоглогч хайх..."
+              value={nationalTeamFilter}
+              onChange={(e) => setNationalTeamFilter(e.target.value)}
+            />
+          </div>
+          <Button onClick={openCreateDialog}>
+            <Plus className="w-4 h-4 mr-2" />
+            Тоглогч нэмэх
+          </Button>
+        </div>
+
+        {nationalTeamLoading ? (
+          <div>Ачааллаж байна...</div>
+        ) : (
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Нэр</TableHead>
+                <TableHead>Овог</TableHead>
+                <TableHead>Нас</TableHead>
+                <TableHead>Зураг</TableHead>
+                <TableHead>Үйлдэл</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {filteredPlayers.map((player: any) => (
+                <TableRow key={player.id}>
+                  <TableCell>{player.firstName}</TableCell>
+                  <TableCell>{player.lastName}</TableCell>
+                  <TableCell>{player.age}</TableCell>
+                  <TableCell>
+                    {player.imageUrl && (
+                      <img
+                        src={player.imageUrl}
+                        alt={player.firstName}
+                        className="w-10 h-10 rounded-full"
+                      />
+                    )}
+                  </TableCell>
+                  <TableCell>
+                    <div className="flex gap-2">
+                      <Button size="sm" variant="outline" onClick={() => openEditDialog(player)}>
+                        <Pencil className="w-4 h-4" />
+                      </Button>
+                      <Button size="sm" variant="destructive" onClick={() => handleDelete(player.id)}>
                         <Trash2 className="w-4 h-4" />
                       </Button>
                     </div>
@@ -1583,6 +1688,107 @@ export default function AdminDashboard() {
                 <ObjectUploader
                   maxNumberOfFiles={1}
                   maxFileSize={5242880} // 5MB
+                  onGetUploadParameters={async () => {
+                    const response = await fetch('/api/objects/upload', {
+                      method: 'POST',
+                      headers: {
+                        'Content-Type': 'application/json'
+                      }
+                    });
+                    const data = await response.json();
+                    return {
+                      method: 'PUT' as const,
+                      url: data.uploadURL
+                    };
+                  }}
+                  onComplete={async (result) => {
+                    if (result.successful && result.successful.length > 0) {
+                      const uploadedFileUrl = result.successful[0].uploadURL;
+
+                      try {
+                        const response = await fetch('/api/objects/finalize', {
+                          method: 'PUT',
+                          headers: {
+                            'Content-Type': 'application/json'
+                          },
+                          body: JSON.stringify({
+                            fileURL: uploadedFileUrl,
+                            isPublic: true
+                          })
+                        });
+                        const data = await response.json();
+
+                        setFormData({ ...formData, imageUrl: data.objectPath });
+                        toast({
+                          title: "Амжилттай",
+                          description: "Зураг амжилттай хуулагдлаа"
+                        });
+                      } catch (error) {
+                        console.error('Error setting image ACL:', error);
+                        setFormData({ ...formData, imageUrl: uploadedFileUrl });
+                        toast({
+                          title: "Анхааруулга",
+                          description: "Зураг хуулагдсан боловч зураг харагдахгүй байж магад"
+                        });
+                      }
+                    }
+                  }}
+                  buttonClassName="w-full"
+                >
+                  <div className="flex items-center gap-2">
+                    <Upload className="w-4 h-4" />
+                    <span>Зураг файл сонгох</span>
+                  </div>
+                </ObjectUploader>
+                {formData.imageUrl && (
+                  <div className="mt-2">
+                    <p className="text-sm text-text-secondary">Зураг хуулагдсан: {formData.imageUrl}</p>
+                  </div>
+                )}
+              </div>
+            </div>
+          </>
+        );
+
+      case 'national-team':
+        return (
+          <>
+            <div className="grid grid-cols-2 gap-4">
+              <div>
+                <Label htmlFor="firstName">Нэр</Label>
+                <Input
+                  id="firstName"
+                  value={formData.firstName || ''}
+                  onChange={(e) => setFormData({ ...formData, firstName: e.target.value })}
+                />
+              </div>
+              <div>
+                <Label htmlFor="lastName">Овог</Label>
+                <Input
+                  id="lastName"
+                  value={formData.lastName || ''}
+                  onChange={(e) => setFormData({ ...formData, lastName: e.target.value })}
+                />
+              </div>
+            </div>
+            <div>
+              <Label htmlFor="age">Нас</Label>
+              <Input
+                id="age"
+                type="number"
+                value={formData.age || ''}
+                onChange={(e) => setFormData({ ...formData, age: parseInt(e.target.value) })}
+              />
+            </div>
+            <div>
+              <Label className="flex items-center gap-2">
+                <Upload className="w-4 h-4" />
+                Зураг оруулах
+              </Label>
+              <div className="space-y-2">
+                <ObjectUploader
+                  maxNumberOfFiles={1}
+                  maxFileSize={5242880}
                   onGetUploadParameters={async () => {
                     const response = await fetch('/api/objects/upload', {
                       method: 'POST',
@@ -2680,6 +2886,8 @@ export default function AdminDashboard() {
         return formData.name && formData.imageUrl; // Add validation for imageUrl
       case 'federation-members':
         return formData.name;
+      case 'national-team':
+        return formData.firstName && formData.lastName && formData.age && formData.imageUrl;
       case 'judges':
         return formData.firstName && formData.lastName;
       case 'coaches':
@@ -2931,6 +3139,10 @@ export default function AdminDashboard() {
           <TabsTrigger value="coaches" className="admin-tab-trigger flex items-center gap-2 data-[state=active]:bg-green-600 font-semibold text-base">
             <UserCog className="w-4 h-4" />
             Дасгалжуулагчид
+          </TabsTrigger>
+          <TabsTrigger value="national-team" className="admin-tab-trigger flex items-center gap-2 data-[state=active]:bg-green-600 font-semibold text-base">
+            <Flag className="w-4 h-4" />
+            Үндэсний шигшээ
           </TabsTrigger>
           <TabsTrigger value="champions" className="admin-tab-trigger flex items-center gap-2 data-[state=active]:bg-green-600 font-semibold text-base">
             <Crown className="w-4 h-4" />
@@ -3265,6 +3477,18 @@ export default function AdminDashboard() {
             </CardHeader>
             <CardContent>
               {renderCoachesTab()}
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="national-team">
+          <Card>
+            <CardHeader>
+              <CardTitle>Үндэсний шигшээ баг</CardTitle>
+              <CardDescription>Шигшээ багийн тоглогчдыг нэмэх, засах, устгах</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {renderNationalTeamTab()}
             </CardContent>
           </Card>
         </TabsContent>

--- a/client/src/pages/national-team.tsx
+++ b/client/src/pages/national-team.tsx
@@ -1,55 +1,20 @@
-import { useState, useMemo } from "react";
 import { useQuery } from "@tanstack/react-query";
 import Navigation from "@/components/navigation";
 import PageWithLoading from "@/components/PageWithLoading";
-import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
-import { Button } from "@/components/ui/button";
-import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
+import { Card, CardContent } from "@/components/ui/card";
 
-interface PlayerRecord {
-  players: { id: string };
-  users?: {
-    firstName?: string;
-    lastName?: string;
-    profileImageUrl?: string | null;
-    province?: string | null; // Using province as country placeholder
-  };
+interface NationalTeamPlayer {
+  id: string;
+  firstName: string;
+  lastName: string;
+  age?: number;
+  imageUrl?: string | null;
 }
 
 export default function NationalTeamPage() {
-  const { data: players = [], isLoading } = useQuery<PlayerRecord[]>({
-    queryKey: ["/api/players"],
+  const { data: players = [], isLoading } = useQuery<NationalTeamPlayer[]>({
+    queryKey: ["/api/national-team"],
   });
-  const [country, setCountry] = useState("all");
-  const [team, setTeam] = useState<PlayerRecord[]>([]);
-
-  const countries = useMemo(() => {
-    const set = new Set<string>();
-    players.forEach((p) => {
-      const c = p.users?.province || "Unknown";
-      set.add(c);
-    });
-    return Array.from(set);
-  }, [players]);
-
-  const filteredPlayers = useMemo(() => {
-    return players.filter((p) => {
-      const c = p.users?.province || "Unknown";
-      return country === "all" || c === country;
-    });
-  }, [players, country]);
-
-  const addToTeam = (player: PlayerRecord) => {
-    setTeam((prev) =>
-      prev.some((p) => p.players.id === player.players.id)
-        ? prev
-        : [...prev, player]
-    );
-  };
-
-  const removeFromTeam = (id: string) => {
-    setTeam((prev) => prev.filter((p) => p.players.id !== id));
-  };
 
   return (
     <PageWithLoading>
@@ -58,104 +23,36 @@ export default function NationalTeamPage() {
         <h1 className="text-4xl font-bold text-white mb-6 text-center">
           Үндэсний шигшээ
         </h1>
-
-        <Card className="mb-8 bg-gray-800 text-white">
-          <CardHeader>
-            <CardTitle>Шигшээ бүрэлдэхүүн</CardTitle>
-          </CardHeader>
-          <CardContent>
-            {team.length === 0 && (
-              <p className="text-gray-400">Одоогоор сонгосон тоглогч алга.</p>
-            )}
-            {team.length > 0 && (
-              <ul className="space-y-2">
-                {team.map((p) => (
-                  <li key={p.players.id} className="flex items-center justify-between">
-                    <span>
-                      {p.users?.firstName} {p.users?.lastName}
-                    </span>
-                    <Button
-                      variant="destructive"
-                      size="sm"
-                      onClick={() => removeFromTeam(p.players.id)}
-                    >
-                      Хасах
-                    </Button>
-                  </li>
-                ))}
-              </ul>
-            )}
-          </CardContent>
-        </Card>
-
-        <div className="mb-6">
-          <Select value={country} onValueChange={setCountry}>
-            <SelectTrigger className="w-full sm:w-64">
-              <SelectValue placeholder="Улс сонгох" />
-            </SelectTrigger>
-            <SelectContent>
-              <SelectItem value="all">Бүх улс</SelectItem>
-              {countries.map((c) => (
-                <SelectItem key={c} value={c}>
-                  {c}
-                </SelectItem>
-              ))}
-            </SelectContent>
-          </Select>
-        </div>
-
         {isLoading ? (
           <div className="flex justify-center py-10">
             <div className="animate-spin rounded-full h-10 w-10 border-b-2 border-white"></div>
           </div>
         ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
-            {filteredPlayers.map((player) => {
-              const inTeam = team.some((p) => p.players.id === player.players.id);
-              const countryName = player.users?.province || "Unknown";
-              return (
-                <Card key={player.players.id} className="bg-gray-800 text-white">
-                  <CardContent className="p-4 flex items-center justify-between">
-                    <div className="flex items-center gap-4">
-                      {player.users?.profileImageUrl ? (
-                        <img
-                          src={player.users.profileImageUrl}
-                          className="w-12 h-12 rounded-full object-cover"
-                          alt=""
-                        />
-                      ) : (
-                        <div className="w-12 h-12 rounded-full bg-gray-700 flex items-center justify-center">
-                          <span className="text-sm">N/A</span>
-                        </div>
-                      )}
-                      <div>
-                        <p className="font-semibold">
-                          {player.users?.firstName} {player.users?.lastName}
-                        </p>
-                        <p className="text-sm text-gray-400">{countryName}</p>
-                      </div>
-                    </div>
-                    {inTeam ? (
-                      <Button
-                        variant="destructive"
-                        size="sm"
-                        onClick={() => removeFromTeam(player.players.id)}
-                      >
-                        Хасах
-                      </Button>
-                    ) : (
-                      <Button size="sm" onClick={() => addToTeam(player)}>
-                        Нэмэх
-                      </Button>
+          <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-6">
+            {players.map((player) => (
+              <Card key={player.id} className="overflow-hidden">
+                {player.imageUrl && (
+                  <img
+                    src={player.imageUrl}
+                    alt={`${player.firstName} ${player.lastName}`}
+                    className="w-full h-48 object-cover"
+                  />
+                )}
+                <CardContent className="p-4 bg-gradient-to-r from-orange-700 to-red-700 text-white">
+                  <div className="flex flex-col">
+                    <span className="text-xl font-semibold">
+                      {player.firstName} {player.lastName}
+                    </span>
+                    {player.age !== undefined && (
+                      <span className="text-sm text-gray-200">{player.age} нас</span>
                     )}
-                  </CardContent>
-                </Card>
-              );
-            })}
+                  </div>
+                </CardContent>
+              </Card>
+            ))}
           </div>
         )}
       </div>
     </PageWithLoading>
   );
 }
-

--- a/server/storage.ts
+++ b/server/storage.ts
@@ -19,6 +19,7 @@ import {
   judges,
   clubCoaches,
   pastChampions,
+  nationalTeamPlayers,
   tournamentTeams,
   tournamentTeamPlayers,
   leagueMatches,
@@ -54,6 +55,8 @@ import {
   type InsertBranch,
   type FederationMember,
   type InsertFederationMember,
+  type NationalTeamPlayer,
+  type InsertNationalTeamPlayer,
   type Judge,
   type InsertJudge,
   type ClubCoach,
@@ -195,6 +198,12 @@ export interface IStorage {
   createFederationMember(member: InsertFederationMember): Promise<FederationMember>;
   updateFederationMember(id: string, member: Partial<InsertFederationMember>): Promise<FederationMember | undefined>;
   deleteFederationMember(id: string): Promise<boolean>;
+
+  // National team player operations
+  getAllNationalTeamPlayers(): Promise<NationalTeamPlayer[]>;
+  createNationalTeamPlayer(player: InsertNationalTeamPlayer): Promise<NationalTeamPlayer>;
+  updateNationalTeamPlayer(id: string, player: Partial<InsertNationalTeamPlayer>): Promise<NationalTeamPlayer | undefined>;
+  deleteNationalTeamPlayer(id: string): Promise<boolean>;
 
   // Judge operations
   getAllJudges(type?: string): Promise<Judge[]>;
@@ -1223,6 +1232,49 @@ export class DatabaseStorage implements IStorage {
 
   async deleteFederationMember(id: string): Promise<boolean> {
     const result = await db.delete(federationMembers).where(eq(federationMembers.id, id));
+    return (result.rowCount || 0) > 0;
+  }
+
+  // National team player operations
+  async getAllNationalTeamPlayers(): Promise<NationalTeamPlayer[]> {
+    return await db
+      .select()
+      .from(nationalTeamPlayers)
+      .orderBy(nationalTeamPlayers.createdAt);
+  }
+
+  async createNationalTeamPlayer(
+    playerData: InsertNationalTeamPlayer,
+  ): Promise<NationalTeamPlayer> {
+    const { randomUUID } = await import('crypto');
+    const now = new Date();
+    const [player] = await db
+      .insert(nationalTeamPlayers)
+      .values({
+        ...playerData,
+        id: randomUUID(),
+        createdAt: now,
+      })
+      .returning();
+    return player;
+  }
+
+  async updateNationalTeamPlayer(
+    id: string,
+    playerData: Partial<InsertNationalTeamPlayer>,
+  ): Promise<NationalTeamPlayer | undefined> {
+    const [player] = await db
+      .update(nationalTeamPlayers)
+      .set(playerData)
+      .where(eq(nationalTeamPlayers.id, id))
+      .returning();
+    return player;
+  }
+
+  async deleteNationalTeamPlayer(id: string): Promise<boolean> {
+    const result = await db
+      .delete(nationalTeamPlayers)
+      .where(eq(nationalTeamPlayers.id, id));
     return (result.rowCount || 0) > 0;
   }
 

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -369,6 +369,16 @@ export const federationMembers = pgTable("federation_members", {
   createdAt: timestamp("created_at").defaultNow(),
 });
 
+// National team players table
+export const nationalTeamPlayers = pgTable("national_team_players", {
+  id: varchar("id").primaryKey().default(sql`gen_random_uuid()`),
+  firstName: varchar("first_name").notNull(),
+  lastName: varchar("last_name").notNull(),
+  age: integer("age"),
+  imageUrl: varchar("image_url"),
+  createdAt: timestamp("created_at").defaultNow(),
+});
+
 // Judge type enum
 export const judgeTypeEnum = pgEnum("judge_type", ["domestic", "international"]);
 
@@ -550,6 +560,11 @@ export const insertFederationMemberSchema = createInsertSchema(federationMembers
   createdAt: true,
 });
 
+export const insertNationalTeamPlayerSchema = createInsertSchema(nationalTeamPlayers).omit({
+  id: true,
+  createdAt: true,
+});
+
 export const insertJudgeSchema = createInsertSchema(judges).omit({
   id: true,
   createdAt: true,
@@ -620,6 +635,8 @@ export type InsertBranch = z.infer<typeof insertBranchSchema>;
 export type Branch = typeof branches.$inferSelect;
 export type InsertFederationMember = z.infer<typeof insertFederationMemberSchema>;
 export type FederationMember = typeof federationMembers.$inferSelect;
+export type InsertNationalTeamPlayer = z.infer<typeof insertNationalTeamPlayerSchema>;
+export type NationalTeamPlayer = typeof nationalTeamPlayers.$inferSelect;
 export type InsertJudge = z.infer<typeof insertJudgeSchema>;
 export type Judge = typeof judges.$inferSelect;
 export type InsertClubCoach = z.infer<typeof insertClubCoachSchema>;


### PR DESCRIPTION
## Summary
- add national team player table and types
- expose API and admin routes for national team management
- add admin dashboard tab and public page for national team players

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Property 'losses' does not exist on type '{}')*


------
https://chatgpt.com/codex/tasks/task_e_68badc618db08321a5ad785240c41a2d