### PR TITLE
Link register button to tournament details

### DIFF
--- a/client/src/components/EventHeroRow.tsx
+++ b/client/src/components/EventHeroRow.tsx
@@ -182,8 +182,8 @@ export default function EventHeroRow({ event, priority = false }: EventHeroRowPr
         <Link
           to={
             status === 'upcoming'
-              ? `/events/${event.id}`
-              : `/events/${event.id}#results`
+              ? `/tournament/${event.id}`
+              : `/tournament/${event.id}/results`
           }
           className='mt-4 inline-block rounded-full bg-white text-gray-900 px-4 py-2 text-sm font-bold hover:bg-gray-100 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-2'
         >


### PR DESCRIPTION
## Summary
- Route register buttons on tournament cards to existing tournament detail pages

## Testing
- `npm test` *(fails: Missing script: "test")*
- `npm run check` *(fails: TS errors: Cannot find name 'gtag', etc.)*

------
https://chatgpt.com/codex/tasks/task_e_68baf57206c883218b3f95873dcf706a