### PR TITLE
feat: enable match selection from bracket

### DIFF
--- a/client/src/components/KnockoutBracket.tsx
+++ b/client/src/components/KnockoutBracket.tsx
@@ -23,6 +23,7 @@ interface BracketMatch {
 interface KnockoutBracketProps {
   matches: BracketMatch[];
   onPlayerClick?: (playerId: string) => void;
+  onMatchClick?: (matchId: string) => void;
 }
 
 function getRoundOrder(roundName: string): number {
@@ -38,7 +39,7 @@ function getRoundOrder(roundName: string): number {
   return roundMap[roundName] || 99;
 }
 
-export function KnockoutBracket({ matches, onPlayerClick }: KnockoutBracketProps) {
+export function KnockoutBracket({ matches, onPlayerClick, onMatchClick }: KnockoutBracketProps) {
   const handlePlayerClick = (id?: string) => {
     if (id && onPlayerClick) onPlayerClick(id);
   };
@@ -81,14 +82,15 @@ export function KnockoutBracket({ matches, onPlayerClick }: KnockoutBracketProps
                   const isPlayer2Winner = match.winner?.id === match.player2?.id;
 
                   return (
-                    <div 
-                      key={match.id} 
+                    <div
+                      key={match.id}
                       className={`bracket-match ${isLastRound ? 'final-match' : ''}`}
                       style={{
                         '--match-index': matchIndex,
                         '--round-index': roundIndex,
                         '--total-matches': roundMatches.length
                       } as React.CSSProperties}
+                      onClick={() => onMatchClick?.(match.id)}
                     >
                       {/* Player 1 */}
                       <div 

--- a/client/src/components/KnockoutBracketEditor.tsx
+++ b/client/src/components/KnockoutBracketEditor.tsx
@@ -450,7 +450,11 @@ export const KnockoutBracketEditor: React.FC<BracketEditorProps> = ({
                 </h4>
 
                 {matches.filter(m => m.roundName === roundName).map((match, index) => (
-                  <div key={match.id} className="bg-gray-700 rounded-lg p-4 border border-gray-600 hover:border-green-500 transition-colors">
+                  <div
+                    key={match.id}
+                    id={`match-editor-${match.id}`}
+                    className="bg-gray-700 rounded-lg p-4 border border-gray-600 hover:border-green-500 transition-colors"
+                  >
                     <div className="flex items-center justify-between mb-3">
                       <span className="text-sm font-medium text-gray-200">
                         Тоглолт #{index + 1}

--- a/client/src/pages/admin-tournament-results.tsx
+++ b/client/src/pages/admin-tournament-results.tsx
@@ -1051,6 +1051,12 @@ export default function AdminTournamentResultsPage() {
                             winner: match.winner,
                             position: match.position
                           }))}
+                          onMatchClick={(id) => {
+                            const el = document.getElementById(`match-editor-${id}`);
+                            if (el) {
+                              el.scrollIntoView({ behavior: 'smooth', block: 'start' });
+                            }
+                          }}
                         />
                       </div>
                     </div>


### PR DESCRIPTION
## Summary
- allow clicking bracket matches to trigger custom handler
- scroll admin editor to relevant match when clicked
- attach IDs to match editors for scrolling

## Testing
- `npm run check` *(fails: Property 'lastName' does not exist on type '{}', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c01e0641e08321aa9e3a6d9dd9ccae