### PR TITLE
feat: highlight selected knockout matches

### DIFF
--- a/client/src/components/KnockoutBracketEditor.tsx
+++ b/client/src/components/KnockoutBracketEditor.tsx
@@ -30,17 +30,27 @@ interface BracketEditorProps {
   users: any[];
   onSave: (matches: Match[]) => void;
   qualifiedPlayers?: { id: string; name: string; groupName: string; position: number }[];
+  /**
+   * Currently selected match ID for highlighting from parent components.
+   */
+  selectedMatchId?: string;
+  /**
+   * Callback invoked when a match card in the editor is clicked.
+   * Can be used by parent components to sync selection with other views.
+   */
+  onMatchSelect?: (matchId: string) => void;
 }
 
 export const KnockoutBracketEditor: React.FC<BracketEditorProps> = ({
   initialMatches = [],
   users,
   onSave,
-  qualifiedPlayers = []
+  qualifiedPlayers = [],
+  selectedMatchId,
+  onMatchSelect
 }) => {
   const containerRef = useRef<HTMLDivElement>(null);
   const [matches, setMatches] = useState<Match[]>(initialMatches);
-  const [selectedMatch, setSelectedMatch] = useState<string | null>(null);
   const { toast } = useToast();
 
   // Update matches when initialMatches changes
@@ -453,7 +463,12 @@ export const KnockoutBracketEditor: React.FC<BracketEditorProps> = ({
                   <div
                     key={match.id}
                     id={`match-editor-${match.id}`}
-                    className="bg-gray-700 rounded-lg p-4 border border-gray-600 hover:border-green-500 transition-colors"
+                    onClick={() => onMatchSelect?.(match.id)}
+                    className={`bg-gray-700 rounded-lg p-4 border transition-colors cursor-pointer ${
+                      selectedMatchId === match.id
+                        ? 'border-green-400 ring-2 ring-green-500'
+                        : 'border-gray-600 hover:border-green-500'
+                    }`}
                   >
                     <div className="flex items-center justify-between mb-3">
                       <span className="text-sm font-medium text-gray-200">

--- a/client/src/components/knockout.css
+++ b/client/src/components/knockout.css
@@ -90,6 +90,12 @@
   box-shadow: 0 8px 32px rgba(255, 215, 0, 0.2);
 }
 
+/* Highlight selected match */
+.bracket-match.selected {
+  border-color: rgba(0, 255, 136, 0.8);
+  box-shadow: 0 0 20px rgba(0, 255, 136, 0.4);
+}
+
 .bracket-team {
   display: flex;
   align-items: center;

--- a/client/src/pages/admin-tournament-results.tsx
+++ b/client/src/pages/admin-tournament-results.tsx
@@ -89,6 +89,8 @@ export default function AdminTournamentResultsPage() {
   // State for editing
   const [groupStageTables, setGroupStageTables] = useState<GroupStageTable[]>([]);
   const [knockoutMatches, setKnockoutMatches] = useState<KnockoutMatch[]>([]);
+  // Track which bracket match is selected to sync bracket view and editor
+  const [selectedBracketMatchId, setSelectedBracketMatchId] = useState<string | null>(null);
   const [finalRankings, setFinalRankings] = useState<FinalRanking[]>([]);
   const [isPublished, setIsPublished] = useState(false);
   const [customParticipationTypes, setCustomParticipationTypes] = useState<string[]>([]);
@@ -1051,7 +1053,9 @@ export default function AdminTournamentResultsPage() {
                             winner: match.winner,
                             position: match.position
                           }))}
+                          selectedMatchId={selectedBracketMatchId || undefined}
                           onMatchClick={(id) => {
+                            setSelectedBracketMatchId(id);
                             const el = document.getElementById(`match-editor-${id}`);
                             if (el) {
                               el.scrollIntoView({ behavior: 'smooth', block: 'start' });
@@ -1102,6 +1106,8 @@ export default function AdminTournamentResultsPage() {
                     })}
                     users={allUsers} // Pass allUsers, but logic inside will use participants
                     qualifiedPlayers={getQualifiedPlayers()}
+                    selectedMatchId={selectedBracketMatchId || undefined}
+                    onMatchSelect={setSelectedBracketMatchId}
                     onSave={(newMatches) => {
                       // Convert back to original format and preserve individual scores
                       const convertedMatches = newMatches.map(match => ({


### PR DESCRIPTION
## Summary
- highlight knockout matches when selected
- sync bracket and editor selections

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: Property 'lastName' does not exist on type '{}')

------
https://chatgpt.com/codex/tasks/task_e_68c0233afdb88321be2aa81e815de132