### PR TITLE
fix: show selected player name

### DIFF
--- a/client/src/components/KnockoutBracketEditor.tsx
+++ b/client/src/components/KnockoutBracketEditor.tsx
@@ -165,9 +165,14 @@ export const KnockoutBracketEditor: React.FC<BracketEditorProps> = ({
   const getAvailableUsers = (matchId: string, position: 'player1' | 'player2') => {
     const selectedIds = getSelectedPlayerIds();
 
-    // Remove current match's other player from selected IDs for this position
+    // Remove current match's players from selected IDs so their names appear in the dropdown
     const currentMatch = matches.find(m => m.id === matchId);
     if (currentMatch) {
+      const currentPlayer = currentMatch[position];
+      if (currentPlayer?.id && currentPlayer.id !== 'lucky_draw') {
+        selectedIds.delete(currentPlayer.id);
+      }
+
       const otherPlayer = position === 'player1' ? currentMatch.player2 : currentMatch.player1;
       if (otherPlayer?.id && otherPlayer.id !== 'lucky_draw') {
         selectedIds.delete(otherPlayer.id);


### PR DESCRIPTION
## Summary
- ensure selected players remain in dropdown options so their names appear

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: client/src/pages/player-profile.tsx(249,72): error TS2339: Property 'lastName' does not exist on type '{}', ...)*

------
https://chatgpt.com/codex/tasks/task_e_68c028c9a9b08321a8a7bef63392a842