### PR TITLE
style: modernize knockout bracket and refresh results

### DIFF
--- a/client/src/components/knockout.css
+++ b/client/src/components/knockout.css
@@ -1,9 +1,9 @@
 
 .tournament-bracket-container {
-  background: linear-gradient(135deg, #1a1a2e 0%, #16213e 100%);
+  background: #fff;
   min-height: 100vh;
   padding: 2rem;
-  color: white;
+  color: #111;
   overflow-x: auto;
   overflow-y: auto;
 }
@@ -28,31 +28,16 @@
 }
 
 .round-header {
-  margin-bottom: 2rem;
+  margin-bottom: 1rem;
   text-align: center;
-  position: sticky;
-  top: 0;
-  z-index: 10;
-  background: rgba(26, 26, 46, 0.95);
-  padding: 1rem;
-  border-radius: 1rem;
-  backdrop-filter: blur(10px);
 }
 
 .round-header h3 {
-  background: linear-gradient(45deg, #00ff88, #00ccff);
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  font-size: 1.2rem;
-  font-weight: bold;
+  font-size: 0.9rem;
+  font-weight: 600;
+  text-transform: uppercase;
+  color: #555;
   margin: 0;
-  padding: 0.5rem 1rem;
-  border: 2px solid transparent;
-  border-radius: 1rem;
-  background-origin: border-box;
-  background-image: linear-gradient(#1a1a2e, #1a1a2e), linear-gradient(45deg, #00ff88, #00ccff);
-  background-clip: padding-box, border-box;
 }
 
 .matches-container {
@@ -69,31 +54,14 @@
   position: relative;
   display: flex;
   flex-direction: column;
-  width: 280px;
-  border-radius: 12px;
-  overflow: hidden;
-  box-shadow: 0 8px 32px rgba(0, 255, 136, 0.15);
-  transition: all 0.3s ease;
-  background: rgba(255, 255, 255, 0.05);
-  border: 2px solid rgba(255, 255, 255, 0.1);
-  backdrop-filter: blur(10px);
-}
-
-.bracket-match:hover {
-  transform: translateY(-4px);
-  box-shadow: 0 16px 48px rgba(0, 255, 136, 0.25);
-  border-color: rgba(0, 255, 136, 0.4);
-}
-
-.bracket-match.final-match {
-  border: 2px solid rgba(255, 215, 0, 0.6);
-  box-shadow: 0 8px 32px rgba(255, 215, 0, 0.2);
+  width: 250px;
+  border: 1px solid #ddd;
+  background: #fff;
 }
 
 /* Highlight selected match */
 .bracket-match.selected {
-  border-color: rgba(0, 255, 136, 0.8);
-  box-shadow: 0 0 20px rgba(0, 255, 136, 0.4);
+  border-color: #1976d2;
 }
 
 .bracket-team {
@@ -101,63 +69,44 @@
   align-items: center;
   justify-content: space-between;
   width: 100%;
-  height: 60px;
-  padding: 0 1.5rem;
+  height: 40px;
+  padding: 0 0.75rem;
   position: relative;
   cursor: pointer;
-  transition: all 0.3s ease;
-  background: rgba(255, 255, 255, 0.03);
+  background: #fff;
 }
 
 .bracket-team:hover {
-  background: rgba(0, 255, 136, 0.1);
+  background: #f5f5f5;
 }
 
-.bracket-team.winner {
-  background: linear-gradient(135deg, rgba(0, 255, 136, 0.2), rgba(0, 204, 255, 0.1));
-  border-left: 4px solid #00ff88;
-}
-
-.bracket-team.winner .team-name {
-  color: #00ff88;
-  font-weight: bold;
-}
-
+.bracket-team.winner .team-name,
 .bracket-team.winner .team-score {
-  color: #00ff88;
-  font-weight: bold;
-  font-size: 1.3rem;
+  color: #d32f2f;
+  font-weight: 600;
 }
 
 .team-top {
-  border-radius: 12px 12px 0 0;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
-}
-
-.team-bottom {
-  border-radius: 0 0 12px 12px;
+  border-bottom: 1px solid #eee;
 }
 
 .team-name {
-  color: #ffffff;
-  font-size: 1rem;
+  color: #111;
+  font-size: 0.85rem;
   font-weight: 500;
   text-overflow: ellipsis;
   overflow: hidden;
   white-space: nowrap;
   flex: 1;
-  margin-right: 1rem;
+  margin-right: 0.5rem;
 }
 
 .team-score {
-  color: #cccccc;
-  font-size: 1.2rem;
-  font-weight: bold;
-  min-width: 40px;
-  text-align: center;
-  background: rgba(0, 0, 0, 0.3);
-  border-radius: 8px;
-  padding: 0.25rem 0.5rem;
+  color: #555;
+  font-size: 0.85rem;
+  font-weight: 600;
+  min-width: 20px;
+  text-align: right;
 }
 
 /* Bracket Connectors */
@@ -166,29 +115,25 @@
   right: -2rem;
   top: 50%;
   transform: translateY(-50%);
-  z-index: 5;
 }
 
 .connector-line {
-  background: linear-gradient(45deg, #00ff88, #00ccff);
-  opacity: 0.8;
+  background: #ccc;
   position: absolute;
 }
 
 .connector-line.horizontal {
   width: 2rem;
-  height: 3px;
+  height: 1px;
   right: 0;
-  top: -1.5px;
-  border-radius: 2px;
+  top: -0.5px;
 }
 
 .connector-line.vertical {
-  width: 3px;
-  height: calc(2rem + 60px);
-  right: -1.5px;
-  top: -30px;
-  border-radius: 2px;
+  width: 1px;
+  height: calc(2rem + 40px);
+  right: -1px;
+  top: -20px;
 }
 
 /* Advanced connecting lines for multi-round brackets */
@@ -198,11 +143,9 @@
   right: -2rem;
   top: 50%;
   width: 2rem;
-  height: 3px;
-  background: linear-gradient(45deg, #00ff88, #00ccff);
-  opacity: 0.8;
+  height: 1px;
+  background: #ccc;
   transform: translateY(-50%);
-  border-radius: 2px;
 }
 
 /* Vertical connectors between matches in same round */
@@ -212,38 +155,29 @@
   right: -2rem;
   top: 30%;
   bottom: 30%;
-  width: 3px;
-  background: linear-gradient(to bottom, #00ff88, #00ccff);
-  opacity: 0.6;
-  border-radius: 2px;
-  z-index: 1;
+  width: 1px;
+  background: #ccc;
 }
 
 /* Third Place Bracket */
 .third-place-bracket {
   margin-top: 4rem;
   padding-top: 2rem;
-  border-top: 3px solid rgba(255, 165, 0, 0.4);
+  border-top: 1px solid #ddd;
   display: flex;
   flex-direction: column;
   align-items: center;
-  background: linear-gradient(135deg, rgba(255, 165, 0, 0.05), rgba(255, 140, 0, 0.05));
-  border-radius: 2rem;
+  background: #fff;
   padding: 2rem;
 }
 
 .third-place-match {
-  border: 2px solid rgba(255, 165, 0, 0.6);
-  box-shadow: 0 8px 32px rgba(255, 165, 0, 0.2);
+  border: 1px solid #ddd;
 }
 
 .third-place-bracket .round-header h3 {
-  background: linear-gradient(45deg, #ffa500, #ff8c00);
-  background-clip: text;
-  -webkit-background-clip: text;
-  -webkit-text-fill-color: transparent;
-  background-image: linear-gradient(#1a1a2e, #1a1a2e), linear-gradient(45deg, #ffa500, #ff8c00);
-  background-clip: padding-box, border-box;
+  color: #555;
+  background: none;
 }
 
 /* Responsive Design */
@@ -340,22 +274,18 @@
 
 /* Glow effect for winners */
 .bracket-team.winner {
-  box-shadow: 
-    inset 0 0 20px rgba(0, 255, 136, 0.2),
-    0 0 20px rgba(0, 255, 136, 0.1);
+  box-shadow: none;
 }
 
-/* Enhanced final match styling */
+/* Final match styling */
 .final-match .bracket-team.winner {
-  background: linear-gradient(135deg, rgba(255, 215, 0, 0.3), rgba(255, 165, 0, 0.2));
-  border-left: 4px solid #ffd700;
-  box-shadow: 
-    inset 0 0 20px rgba(255, 215, 0, 0.3),
-    0 0 30px rgba(255, 215, 0, 0.2);
+  background: #fff;
+  border-left: none;
+  box-shadow: none;
 }
 
 .final-match .bracket-team.winner .team-name,
 .final-match .bracket-team.winner .team-score {
-  color: #ffd700;
-  text-shadow: 0 0 10px rgba(255, 215, 0, 0.5);
+  color: #d32f2f;
+  text-shadow: none;
 }

--- a/client/src/pages/admin-tournament-results.tsx
+++ b/client/src/pages/admin-tournament-results.tsx
@@ -325,6 +325,8 @@ export default function AdminTournamentResultsPage() {
         title: "Амжилттай хадгалагдлаа",
         description: "Тэмцээний үр дүн амжилттай шинэчлэгдлээ",
       });
+      // Refresh tournament info and results views
+      queryClient.invalidateQueries({ queryKey: ['/api/tournaments', tournamentId] });
       queryClient.invalidateQueries({ queryKey: ['/api/tournaments', tournamentId, 'results'] });
     },
     onError: () => {


### PR DESCRIPTION
## Summary
- Restyle knockout bracket to light theme with compact match blocks and simplified connectors
- Invalidate tournament queries after saving results so public pages refresh brackets

## Testing
- `npm run check` *(fails: Property 'lastName' does not exist on type '{}', and other TypeScript errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c03ba207b88321a887c7257197e487