### PR TITLE
style: align knockout bracket matches to top

### DIFF
--- a/client/src/components/knockout.css
+++ b/client/src/components/knockout.css
@@ -45,9 +45,7 @@
   flex-direction: column;
   gap: 2rem;
   position: relative;
-  height: 100%;
-  justify-content: space-around;
-  min-height: 600px;
+  justify-content: flex-start;
 }
 
 .bracket-match {
@@ -153,8 +151,8 @@
   content: '';
   position: absolute;
   right: -2rem;
-  top: 30%;
-  bottom: 30%;
+  top: 0;
+  bottom: 0;
   width: 1px;
   background: #374151;
 }


### PR DESCRIPTION
## Summary
- Align knockout bracket matches to top for a more compact layout
- Extend vertical connector lines to span the full round height

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check` *(fails: Property 'lastName' does not exist on type '{}', and other TS errors)*

------
https://chatgpt.com/codex/tasks/task_e_68c04b7045908321ae7c205b62c4fcd5