### PR TITLE
fix: handle empty rounds in knockout bracket

### DIFF
--- a/client/src/components/KnockoutBracket.tsx
+++ b/client/src/components/KnockoutBracket.tsx
@@ -85,11 +85,11 @@ export function KnockoutBracket({
             </div>
 
             <div className="matches-container">
-              {matchesByRound[round]
+              {[...(matchesByRound[round] ?? [])]
                 .sort((a, b) => (a.position?.y || 0) - (b.position?.y || 0))
                 .map((match) => (
-                  <div 
-                    key={match.id} 
+                  <div
+                    key={match.id}
                     className={`match-box ${onMatchClick ? 'clickable' : ''}`}
                     onClick={() => onMatchClick?.(match)}
                   >


### PR DESCRIPTION
## Summary
- prevent runtime crash in KnockoutBracket when no matches exist for a round

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c13d236dfc8321a92d736bfaf938aa