### PR TITLE
Handle legacy knockout rounds when rendering brackets

### DIFF
--- a/client/src/lib/knockout.ts
+++ b/client/src/lib/knockout.ts
@@ -1,0 +1,59 @@
+export interface RawKnockoutMatch {
+  id: string;
+  round: number | string;
+  [key: string]: any;
+}
+
+/**
+ * Normalizes knockout match rounds so that legacy string values like
+ * "Хагас финал" are converted to sequential numeric rounds starting from 1.
+ * This ensures newer bracket components that expect numeric rounds continue
+ * to work with older stored data.
+ */
+export function normalizeKnockoutMatches(matches: RawKnockoutMatch[]): RawKnockoutMatch[] {
+  if (!Array.isArray(matches) || matches.length === 0) return [];
+
+  const thirdPlace = matches.filter(
+    m => m.round === '3-р байрын тоглолт' || m.id === 'third_place_playoff'
+  );
+  const others = matches.filter(
+    m => !(m.round === '3-р байрын тоглолт' || m.id === 'third_place_playoff')
+  );
+
+  const roundOrder = [
+    '1/64 финал',
+    '1/32 финал',
+    '1/16 финал',
+    '1/8 финал',
+    'Дөрөвний финал',
+    'Хагас финал',
+    'Финал'
+  ];
+
+  const roundNames = Array.from(
+    new Set(
+      others
+        .map(m => (typeof m.round === 'string' ? m.round : ''))
+        .filter(Boolean)
+    )
+  );
+  const sortedRoundNames = roundNames.sort(
+    (a, b) => roundOrder.indexOf(a) - roundOrder.indexOf(b)
+  );
+
+  const roundMap = new Map<string, number>();
+  sortedRoundNames.forEach((name, idx) => roundMap.set(name, idx + 1));
+
+  const normalized = others.map(m => ({
+    ...m,
+    round: typeof m.round === 'number' ? m.round : roundMap.get(m.round as string) || 0
+  }));
+
+  const totalRounds = roundMap.size === 0 ? 1 : roundMap.size;
+  const normalizedThird = thirdPlace.map(m => ({
+    ...m,
+    round: typeof m.round === 'number' ? m.round : totalRounds
+  }));
+
+  return [...normalized, ...normalizedThird];
+}

--- a/client/src/pages/tournament-full-info.tsx
+++ b/client/src/pages/tournament-full-info.tsx
@@ -14,6 +14,7 @@ import { ArrowLeft, User, Upload } from "lucide-react";
 import { useAuth } from "@/hooks/useAuth";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
+import { normalizeKnockoutMatches } from "@/lib/knockout";
 import type { Tournament, TournamentResults } from "@shared/schema";
 import { UserAutocomplete } from "@/components/UserAutocomplete";
 import { ObjectUploader } from "@/components/ObjectUploader";
@@ -26,7 +27,7 @@ interface GroupStageGroup {
 
 interface KnockoutMatch {
   id: string;
-  round: number;
+  round: number | string;
   player1?: { id: string; name: string };
   player2?: { id: string; name: string };
   player1Score?: string;
@@ -274,7 +275,8 @@ interface Participant {
   }
 
   const groupStageResults: GroupStageGroup[] = (results?.groupStageResults as any) || [];
-  const knockoutResults: KnockoutMatch[] = (results?.knockoutResults as any) || [];
+  const rawKnockoutResults: KnockoutMatch[] = (results?.knockoutResults as any) || [];
+  const knockoutResults = normalizeKnockoutMatches(rawKnockoutResults) as KnockoutMatch[];
   const finalRankings: FinalRanking[] = (results?.finalRankings as any) || [];
 
   const formatDate = (d: string | Date) => format(new Date(d), 'yyyy-MM-dd');
@@ -433,7 +435,7 @@ interface Participant {
                 <KnockoutBracket
                   matches={knockoutResults.map(match => ({
                     id: match.id,
-                    round: match.round,
+                    round: Number(match.round),
                     player1: match.player1,
                     player2: match.player2,
                     winner: match.winner,

--- a/client/src/pages/tournament-results.tsx
+++ b/client/src/pages/tournament-results.tsx
@@ -9,6 +9,7 @@ import { ArrowLeft, Trophy, Medal, Users, Calendar } from "lucide-react";
 import { format } from "date-fns";
 import { useAuth } from "@/hooks/useAuth";
 import { KnockoutBracket } from "@/components/KnockoutBracket";
+import { normalizeKnockoutMatches } from "@/lib/knockout";
 import PageWithLoading from "@/components/PageWithLoading";
 import type { Tournament, TournamentResults } from "@shared/schema";
 
@@ -43,7 +44,7 @@ interface GroupStageGroup {
 
 interface KnockoutMatch {
   id: string;
-  round: number;
+  round: number | string;
   player1?: { id: string; name: string };
   player2?: { id: string; name: string };
   player1Score?: string;
@@ -142,7 +143,8 @@ export default function TournamentResultsPage() {
   const finalRankingsByType = (results.finalRankings as Record<string, FinalRanking[]> || {});
 
   const groupStageResults: GroupStageGroup[] = groupStageResultsByType[activeType] || [];
-  const knockoutResults: KnockoutMatch[] = knockoutResultsByType[activeType] || [];
+  const rawKnockoutResults: KnockoutMatch[] = knockoutResultsByType[activeType] || [];
+  const knockoutResults: KnockoutMatch[] = normalizeKnockoutMatches(rawKnockoutResults) as KnockoutMatch[];
   const finalRankings: FinalRanking[] = finalRankingsByType[activeType] || [];
 
   const navigateToProfile = (playerId: string) => {
@@ -264,7 +266,7 @@ export default function TournamentResultsPage() {
                     <KnockoutBracket
                       matches={knockoutResults.map(match => ({
                         id: match.id,
-                        round: match.round,
+                        round: Number(match.round),
                         player1: match.player1,
                         player2: match.player2,
                         winner: match.winner,
@@ -420,9 +422,9 @@ export default function TournamentResultsPage() {
                 <div className="space-y-6">
                   {/* Semifinals */}
                   {(() => {
-                    const totalRounds = Math.max(...knockoutResults.map(m => m.round), 0);
+                    const totalRounds = Math.max(...knockoutResults.map(m => Number(m.round)), 0);
                     const semifinals = knockoutResults.filter(match =>
-                      match.round === totalRounds - 1 && match.id !== 'third_place_playoff'
+                      Number(match.round) === totalRounds - 1 && match.id !== 'third_place_playoff'
                     );
 
                     if (semifinals.length > 0) {
@@ -485,9 +487,9 @@ export default function TournamentResultsPage() {
 
                   {/* Finals */}
                   {(() => {
-                    const totalRounds = Math.max(...knockoutResults.map(m => m.round), 0);
+                    const totalRounds = Math.max(...knockoutResults.map(m => Number(m.round)), 0);
                     const finals = knockoutResults.filter(match =>
-                      match.round === totalRounds && match.id !== 'third_place_playoff'
+                      Number(match.round) === totalRounds && match.id !== 'third_place_playoff'
                     );
 
                     if (finals.length > 0) {


### PR DESCRIPTION
## Summary
- convert legacy string-based knockout round labels into numeric rounds
- ensure admin and public results pages normalize knockout data before rendering brackets

## Testing
- `npm test` (fails: Missing script "test")
- `npm run check` (fails: 339 TypeScript errors)

------
https://chatgpt.com/codex/tasks/task_e_68c14d7a795c8321af1a2870dd0f90a1