### PR TITLE
Fix player edit crash and show bracket links

### DIFF
--- a/client/src/components/KnockoutBracket.tsx
+++ b/client/src/components/KnockoutBracket.tsx
@@ -165,7 +165,7 @@ export function KnockoutBracket({
         const updatedMatch = { ...match };
         
         if (field === 'player1' || field === 'player2') {
-          const selectedPlayer = availablePlayers.find(p => p.name === value || p.id === value);
+          const selectedPlayer = availablePlayers.find(p => p.id === value);
           if (selectedPlayer) {
             updatedMatch[field as 'player1' | 'player2'] = selectedPlayer;
           }
@@ -227,12 +227,9 @@ export function KnockoutBracket({
                         <div className="player-name">
                           {isAdmin && editingField === `${match.id}_player1` ? (
                             <Select
-                              value={editingValue}
+                              value={editingValue || undefined}
                               onValueChange={(value) => {
-                                const selectedPlayer = availablePlayers.find(p => p.id === value);
-                                if (selectedPlayer) {
-                                  saveEdit(match.id, 'player1', selectedPlayer.name);
-                                }
+                                saveEdit(match.id, 'player1', value);
                               }}
                               onOpenChange={(open) => {
                                 if (!open) cancelEdit();
@@ -255,7 +252,7 @@ export function KnockoutBracket({
                               onClick={(e) => {
                                 e.stopPropagation();
                                 if (isAdmin) {
-                                  startEdit(`${match.id}_player1`, match.player1?.name || '');
+                                  startEdit(`${match.id}_player1`, match.player1?.id || '');
                                 } else {
                                   handlePlayerClick(match.player1, match, e);
                                 }
@@ -308,12 +305,9 @@ export function KnockoutBracket({
                         <div className="player-name">
                           {isAdmin && editingField === `${match.id}_player2` ? (
                             <Select
-                              value={editingValue}
+                              value={editingValue || undefined}
                               onValueChange={(value) => {
-                                const selectedPlayer = availablePlayers.find(p => p.id === value);
-                                if (selectedPlayer) {
-                                  saveEdit(match.id, 'player2', selectedPlayer.name);
-                                }
+                                saveEdit(match.id, 'player2', value);
                               }}
                               onOpenChange={(open) => {
                                 if (!open) cancelEdit();
@@ -336,7 +330,7 @@ export function KnockoutBracket({
                               onClick={(e) => {
                                 e.stopPropagation();
                                 if (isAdmin) {
-                                  startEdit(`${match.id}_player2`, match.player2?.name || '');
+                                  startEdit(`${match.id}_player2`, match.player2?.id || '');
                                 } else {
                                   handlePlayerClick(match.player2, match, e);
                                 }

--- a/client/src/components/MatchEditorDrawer.tsx
+++ b/client/src/components/MatchEditorDrawer.tsx
@@ -105,7 +105,7 @@ export function MatchEditorDrawer({
       // Parse existing result
       if (match.winner && match.score) {
         if (match.score === 'BYE') {
-          setWinner('');
+          setWinner('none');
         } else if (match.score.includes('W.O.')) {
           setWinner('WO');
         } else if (match.score.includes('RET')) {

--- a/client/src/components/knockout.css
+++ b/client/src/components/knockout.css
@@ -73,7 +73,7 @@
   padding: 0;
   transition: all 0.3s cubic-bezier(0.4, 0, 0.2, 1);
   box-shadow: 0 4px 12px rgba(0, 0, 0, 0.3);
-  overflow: hidden;
+  overflow: visible;
 }
 
 .match-box:hover {


### PR DESCRIPTION
## Summary
- Use player IDs in KnockoutBracket editor to prevent runtime error when changing players
- Adjust BYE match winner handling in MatchEditorDrawer
- Make bracket connectors visible by allowing match boxes to overflow

## Testing
- `npm run check` *(fails: TS errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68c173463c9c8321a48abd4683c4e9a6