### PR TITLE
Display surname before given name

### DIFF
--- a/client/src/components/MatchEditorDrawer.tsx
+++ b/client/src/components/MatchEditorDrawer.tsx
@@ -24,6 +24,7 @@ import {
   Trash2
 } from 'lucide-react';
 import { useToast } from '@/hooks/use-toast';
+import { formatName } from '@/lib/utils';
 import { Command, CommandEmpty, CommandGroup, CommandInput, CommandItem } from '@/components/ui/command';
 import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover';
 
@@ -465,7 +466,7 @@ export function MatchEditorDrawer({
   const filteredPlayersA = useMemo(() => {
     if (!playerASearch.trim()) return availablePlayers;
     return availablePlayers.filter(player => {
-      const playerName = player.name || player.fullName || `${player.firstName || ''} ${player.lastName || ''}`.trim();
+      const playerName = player.name || player.fullName || formatName(player.firstName || '', player.lastName || '');
       const playerEmail = player.email || '';
       return playerName.toLowerCase().includes(playerASearch.toLowerCase()) ||
              playerEmail.toLowerCase().includes(playerASearch.toLowerCase());
@@ -475,7 +476,7 @@ export function MatchEditorDrawer({
   const filteredPlayersB = useMemo(() => {
     if (!playerBSearch.trim()) return availablePlayers;
     return availablePlayers.filter(player => {
-      const playerName = player.name || player.fullName || `${player.firstName || ''} ${player.lastName || ''}`.trim();
+      const playerName = player.name || player.fullName || formatName(player.firstName || '', player.lastName || '');
       const playerEmail = player.email || '';
       return playerName.toLowerCase().includes(playerBSearch.toLowerCase()) ||
              playerEmail.toLowerCase().includes(playerBSearch.toLowerCase());

--- a/client/src/components/ParticipantsTab.tsx
+++ b/client/src/components/ParticipantsTab.tsx
@@ -6,6 +6,7 @@ import { Badge } from '@/components/ui/badge';
 import { Card, CardContent, CardHeader, CardTitle } from '@/components/ui/card';
 import { Skeleton } from '@/components/ui/skeleton';
 import { User, Users } from 'lucide-react';
+import { formatName } from '@/lib/utils';
 
 const categories = [
   { value: 'all', label: 'Бүгд' },
@@ -131,14 +132,14 @@ export function ParticipantsTab({ tournamentId }: ParticipantsTabProps) {
                 >
                   <Avatar className="h-10 w-10">
                     <AvatarFallback>
-                      {getInitials(participant.playerName || participant.fullName || `${participant.firstName || ''} ${participant.lastName || ''}`.trim() || 'N/A')}
+                      {getInitials(participant.playerName || participant.fullName || formatName(participant.firstName || '', participant.lastName || '') || 'N/A')}
                     </AvatarFallback>
                   </Avatar>
                   
                   <div className="flex-1">
                     <div className="flex items-center gap-2">
                       <span className="font-medium">
-                        {participant.playerName || participant.fullName || `${participant.firstName || ''} ${participant.lastName || ''}`.trim() || 'Тодорхойгүй'}
+                        {participant.playerName || participant.fullName || formatName(participant.firstName || '', participant.lastName || '') || 'Тодорхойгүй'}
                       </span>
                       {participant.gender && (
                         <span className="text-xs text-muted-foreground">

--- a/client/src/components/RegistrationForm.tsx
+++ b/client/src/components/RegistrationForm.tsx
@@ -10,7 +10,7 @@ import { toast } from "@/hooks/use-toast";
 import { useAuth } from "@/hooks/useAuth";
 import { useMutation, useQuery } from '@tanstack/react-query';
 import { queryClient } from '@/lib/queryClient';
-import { cn } from '@/lib/utils';
+import { cn, formatName } from '@/lib/utils';
 
 type RegistrationFormProps = {
   tournament: {
@@ -322,7 +322,7 @@ export default function RegistrationForm({ tournament, preselectedCategory, onSu
           </Label>
           <div className="flex flex-wrap gap-2">
             <Badge variant="outline" className="px-3 py-1">
-              {profile.fullName || profile.name || `${profile.firstName || ''} ${profile.lastName || ''}`.trim() || 'Нэр тодорхойгүй'}
+              {profile.fullName || profile.name || formatName(profile.firstName || '', profile.lastName || '') || 'Нэр тодорхойгүй'}
             </Badge>
             <Badge variant="outline" className="px-3 py-1">
               {profile.gender === 'male' ? 'Эрэгтэй' : profile.gender === 'female' ? 'Эмэгтэй' : 'Хүйс тодорхойгүй'}

--- a/client/src/components/UserAutocomplete.tsx
+++ b/client/src/components/UserAutocomplete.tsx
@@ -15,7 +15,7 @@ import {
   PopoverContent,
   PopoverTrigger,
 } from "@/components/ui/popover";
-import { cn } from "@/lib/utils";
+import { cn, formatName } from "@/lib/utils";
 import type { User } from "@shared/schema";
 
 interface UserAutocompleteProps {
@@ -49,12 +49,12 @@ export function UserAutocomplete({
 
   const selectedUser = users.find(user => user.id === value);
   const displayValue = selectedUser
-    ? `${selectedUser.firstName} ${selectedUser.lastName}`
+    ? formatName(selectedUser.firstName, selectedUser.lastName)
     : customNameValue || placeholder;
 
   // Filter users based on search term
   const filteredUsers = users.filter(user => {
-    const fullName = `${user.firstName} ${user.lastName}`.toLowerCase();
+    const fullName = formatName(user.firstName, user.lastName).toLowerCase();
     const email = user.email?.toLowerCase() || "";
     const club = user.clubAffiliation?.toLowerCase() || "";
     const search = searchTerm.toLowerCase();
@@ -104,7 +104,7 @@ export function UserAutocomplete({
               >
                 <div className="flex flex-col">
                   <span className="font-medium">
-                    {user.firstName} {user.lastName}
+                    {formatName(user.firstName, user.lastName)}
                   </span>
                   {user.clubAffiliation && (
                     <span className="text-sm text-gray-500">

--- a/client/src/components/tournament-bracket.tsx
+++ b/client/src/components/tournament-bracket.tsx
@@ -3,6 +3,7 @@ import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { Trophy, Calendar, Users, MapPin, Settings } from "lucide-react";
+import { formatName } from "@/lib/utils";
 
 interface TournamentBracketProps {
   tournamentId: string;
@@ -124,7 +125,7 @@ export default function TournamentBracket({ tournamentId }: TournamentBracketPro
                             <div className={`flex justify-between items-center p-2 rounded text-sm ${
                               match.winnerId === match.player1Id ? 'bg-green-100 font-medium' : 'bg-gray-50'
                             }`}>
-                              <span>{match.player1?.user?.firstName} {match.player1?.user?.lastName}</span>
+                              <span>{formatName(match.player1?.user?.firstName, match.player1?.user?.lastName)}</span>
                               <span className={match.winnerId === match.player1Id ? 'text-mtta-green font-bold' : 'text-gray-500'}>
                                 {match.status === 'completed' ? '3' : '-'}
                               </span>
@@ -132,7 +133,7 @@ export default function TournamentBracket({ tournamentId }: TournamentBracketPro
                             <div className={`flex justify-between items-center p-2 rounded text-sm ${
                               match.winnerId === match.player2Id ? 'bg-green-100 font-medium' : 'bg-gray-50'
                             }`}>
-                              <span>{match.player2?.user?.firstName} {match.player2?.user?.lastName}</span>
+                              <span>{formatName(match.player2?.user?.firstName, match.player2?.user?.lastName)}</span>
                               <span className={match.winnerId === match.player2Id ? 'text-mtta-green font-bold' : 'text-gray-500'}>
                                 {match.status === 'completed' ? '1' : '-'}
                               </span>

--- a/client/src/lib/utils.ts
+++ b/client/src/lib/utils.ts
@@ -5,6 +5,19 @@ export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs))
 }
 
+export function formatName(
+  firstName?: string | null,
+  lastName?: string | null,
+  useInitial: boolean = false
+): string {
+  const fn = firstName?.trim() || ""
+  const ln = lastName?.trim() || ""
+  if (useInitial && ln) {
+    return `${ln.charAt(0)}. ${fn}`.trim()
+  }
+  return `${ln} ${fn}`.trim()
+}
+
 // Static placeholder SVG used when an image URL is not provided
 export const placeholderImageData =
   'data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iNDAwIiBoZWlnaHQ9iMjQ0IiB2aWV3Qm94PSIwIDAgNDAwIDI0MCIgZmlsbD0ibm9uZSIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj4KPHJlY3Qgd2lkdGg9IjQwMCIgaGVpZ2h0PSIyNDAiIGZpbGw9IiNGM0Y0RjYiLz4KPHBhdGggZD0iTTE2MCAxMDBIMjI1VjE0MEhNMTYwVjEwMFoiIGZpbGw9IiNEOUQ5QkIiLz4KPHBhdGggZD0iTTE3NSAxN0gxNzVWMTE1WiIgZmlsbD0iIzlDQTNBRiIvPgo8L3N2Zz4K';

--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -23,7 +23,7 @@ import RichTextEditor from "@/components/rich-text-editor";
 import { zodResolver } from "@hookform/resolvers/zod";
 import { useForm } from "react-hook-form";
 import * as z from "zod";
-import { getImageUrl } from "@/lib/utils";
+import { getImageUrl, formatName } from "@/lib/utils";
 
 // Import Form components
 import {
@@ -600,7 +600,7 @@ const { data: judges, isLoading: judgesLoading, refetch: judgesRefetch } = useQu
           <TableBody>
             {filteredUsers.map((user: any) => (
               <TableRow key={user.id}>
-                <TableCell>{user.firstName} {user.lastName}</TableCell>
+                <TableCell>{formatName(user.firstName, user.lastName)}</TableCell>
                 <TableCell>{user.email}</TableCell>
                 <TableCell>{user.phone}</TableCell>
                 <TableCell>{user.gender}</TableCell>
@@ -906,7 +906,7 @@ const { data: judges, isLoading: judgesLoading, refetch: judgesRefetch } = useQu
                   <TableCell>{player.age}</TableCell>
                   <TableCell>
                     {player.imageUrl && (
-                      <img src={player.imageUrl} alt={`${player.firstName} ${player.lastName}`} className="w-10 h-10 rounded-full object-cover" />
+                      <img src={player.imageUrl} alt={formatName(player.firstName, player.lastName)} className="w-10 h-10 rounded-full object-cover" />
                     )}
                   </TableCell>
                   <TableCell>
@@ -954,11 +954,11 @@ const { data: judges, isLoading: judgesLoading, refetch: judgesRefetch } = useQu
             <TableBody>
               {judges && Array.isArray(judges) ? judges.map((judge: any) => (
                 <TableRow key={judge.id}>
-                  <TableCell>{judge.firstName} {judge.lastName}</TableCell>
+                  <TableCell>{formatName(judge.firstName, judge.lastName)}</TableCell>
                   <TableCell>{judge.judgeType === 'international' ? 'Олон улсын' : 'Дотоодын'}</TableCell>
                   <TableCell>
                     {judge.imageUrl && (
-                      <img src={judge.imageUrl} alt={judge.firstName} className="w-10 h-10 rounded-full" />
+                      <img src={judge.imageUrl} alt={formatName(judge.firstName, judge.lastName)} className="w-10 h-10 rounded-full" />
                     )}
                   </TableCell>
                   <TableCell>
@@ -1001,7 +1001,7 @@ const { data: judges, isLoading: judgesLoading, refetch: judgesRefetch } = useQu
               {coaches && Array.isArray(coaches) ? coaches.map((coach: any) => (
                 <TableRow key={coach.id}>
                   <TableCell>
-                    {coach.name || `${coach.firstName || ''} ${coach.lastName || ''}`}
+                    {coach.name || formatName(coach.firstName || '', coach.lastName || '')}
                   </TableCell>
                   <TableCell>{coach.clubName}</TableCell>
                   <TableCell>
@@ -1887,7 +1887,7 @@ const { data: judges, isLoading: judgesLoading, refetch: judgesRefetch } = useQu
                   <SelectItem value="none">Хэрэглэгчгүй</SelectItem>
                   {users && Array.isArray(users) ? users.map((user: any) => (
                     <SelectItem key={user.id} value={user.id}>
-                      {user.firstName} {user.lastName}
+                      {formatName(user.firstName, user.lastName)}
                     </SelectItem>
                   )) : null}
                 </SelectContent>
@@ -2295,7 +2295,7 @@ const { data: judges, isLoading: judgesLoading, refetch: judgesRefetch } = useQu
                 <SelectContent>
                   {allUsers && Array.isArray(allUsers) && allUsers.filter((user: any) => user.role === 'player').map((player: any) => (
                     <SelectItem key={player.id} value={player.id}>
-                      {player.firstName} {player.lastName}
+                      {formatName(player.firstName, player.lastName)}
                     </SelectItem>
                   ))}
                 </SelectContent>
@@ -2307,7 +2307,7 @@ const { data: judges, isLoading: judgesLoading, refetch: judgesRefetch } = useQu
                     const player = allUsers && Array.isArray(allUsers) ? allUsers.find((u: any) => u.id === playerId && u.role === 'player') : null;
                     return player ? (
                       <div key={playerId} className="flex items-center justify-between bg-secondary p-2 rounded">
-                        <span className="text-sm">{player.firstName} {player.lastName}</span>
+                        <span className="text-sm">{formatName(player.firstName, player.lastName)}</span>
                         <Button
                           type="button"
                           variant="ghost"

--- a/client/src/pages/admin-player-details.tsx
+++ b/client/src/pages/admin-player-details.tsx
@@ -18,6 +18,7 @@ import Navigation from "@/components/navigation";
 import { useToast } from "@/hooks/use-toast";
 import { apiRequest } from "@/lib/queryClient";
 import { useAuth } from "@/hooks/useAuth";
+import { formatName } from "@/lib/utils";
 
 export default function AdminPlayerDetailsPage() {
   const [match, params] = useRoute("/admin/player/:id");
@@ -214,7 +215,7 @@ export default function AdminPlayerDetailsPage() {
                           <User className="h-12 w-12" />
                         </div>
                       )}
-                      <h2 className="text-2xl font-bold">{playerData?.firstName} {playerData?.lastName}</h2>
+                      <h2 className="text-2xl font-bold">{formatName(playerData?.firstName, playerData?.lastName)}</h2>
                       <div className="flex flex-wrap gap-2 justify-center mt-2">
                         <Badge variant="secondary" className="bg-white/20 text-black">
                           {playerData?.role === 'admin' ? 'Админ' : 'Тоглогч'}

--- a/client/src/pages/home.tsx
+++ b/client/src/pages/home.tsx
@@ -13,6 +13,7 @@ import { Link } from "wouter";
 import { useQuery } from "@tanstack/react-query";
 import PageWithLoading from "@/components/PageWithLoading";
 import { format } from "date-fns";
+import { formatName, getImageUrl } from "@/lib/utils";
 
 // Type definitions for API responses
 interface SliderItem {
@@ -383,13 +384,13 @@ export default function Home() {
                       {player.profileImageUrl ? (
                         <img
                           src={getImageUrl(player.profileImageUrl)}
-                          alt={`${player.firstName} ${player.lastName}`}
+                          alt={formatName(player.firstName, player.lastName)}
                           className="w-16 h-16 rounded-full mx-auto object-cover group-hover:scale-105 transition-transform"
                         />
                       ) : (
                         <div className="w-16 h-16 rounded-full bg-mtta-green text-white flex items-center justify-center mx-auto group-hover:scale-105 transition-transform">
                           <span className="text-lg font-bold">
-                            {player.firstName?.[0]}{player.lastName?.[0]}
+                            {player.lastName?.[0]}{player.firstName?.[0]}
                           </span>
                         </div>
                       )}
@@ -400,7 +401,7 @@ export default function Home() {
                       )}
                     </div>
                     <h4 className="font-medium text-sm text-gray-900 group-hover:text-mtta-green transition-colors">
-                      {player.firstName} {player.lastName}
+                      {formatName(player.firstName, player.lastName)}
                     </h4>
                     {player.rating && (
                       <p className="text-xs text-gray-600">{player.rating} pts</p>

--- a/client/src/pages/judges.tsx
+++ b/client/src/pages/judges.tsx
@@ -5,6 +5,7 @@ import PageWithLoading from "@/components/PageWithLoading";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { Card, CardContent } from "@/components/ui/card";
 import { Avatar, AvatarFallback, AvatarImage } from "@/components/ui/avatar";
+import { formatName } from "@/lib/utils";
 
 interface Judge {
   id: string;
@@ -48,11 +49,11 @@ export default function JudgesPage() {
                     <Card key={judge.id} className="bg-gray-800 text-white hover:bg-gray-700 transition-colors aspect-[3/4] flex flex-col">
                       <CardContent className="flex flex-col items-center justify-center p-8 h-full text-center">
                         <Avatar className="w-40 h-48 mb-6 rounded-lg">
-                          <AvatarImage src={judge.imageUrl} alt={judge.firstName} className="object-cover" />
-                          <AvatarFallback className="text-3xl rounded-lg">{judge.firstName?.[0]}{judge.lastName?.[0]}</AvatarFallback>
+                          <AvatarImage src={judge.imageUrl} alt={formatName(judge.firstName, judge.lastName)} className="object-cover" />
+                          <AvatarFallback className="text-3xl rounded-lg">{judge.lastName?.[0]}{judge.firstName?.[0]}</AvatarFallback>
                         </Avatar>
                         <div>
-                          <div className="font-semibold text-lg mb-1">{judge.firstName} {judge.lastName}</div>
+                          <div className="font-semibold text-lg mb-1">{formatName(judge.firstName, judge.lastName)}</div>
                           <div className="text-sm text-gray-400">Дотоодын шүүгч</div>
                         </div>
                       </CardContent>
@@ -78,11 +79,11 @@ export default function JudgesPage() {
                     <Card key={judge.id} className="bg-gray-800 text-white hover:bg-gray-700 transition-colors aspect-[3/4] flex flex-col">
                       <CardContent className="flex flex-col items-center justify-center p-8 h-full text-center">
                         <Avatar className="w-40 h-48 mb-6 rounded-lg">
-                          <AvatarImage src={judge.imageUrl} alt={judge.firstName} className="object-cover" />
-                          <AvatarFallback className="text-3xl rounded-lg">{judge.firstName?.[0]}{judge.lastName?.[0]}</AvatarFallback>
+                          <AvatarImage src={judge.imageUrl} alt={formatName(judge.firstName, judge.lastName)} className="object-cover" />
+                          <AvatarFallback className="text-3xl rounded-lg">{judge.lastName?.[0]}{judge.firstName?.[0]}</AvatarFallback>
                         </Avatar>
                         <div>
-                          <div className="font-semibold text-lg mb-1">{judge.firstName} {judge.lastName}</div>
+                          <div className="font-semibold text-lg mb-1">{formatName(judge.firstName, judge.lastName)}</div>
                           <div className="text-sm text-gray-400">Олон улсын шүүгч</div>
                         </div>
                       </CardContent>

--- a/client/src/pages/national-team.tsx
+++ b/client/src/pages/national-team.tsx
@@ -2,6 +2,7 @@ import { useQuery } from "@tanstack/react-query";
 import Navigation from "@/components/navigation";
 import PageWithLoading from "@/components/PageWithLoading";
 import { Card, CardContent } from "@/components/ui/card";
+import { formatName } from "@/lib/utils";
 
 interface NationalTeamPlayer {
   id: string;
@@ -34,14 +35,14 @@ export default function NationalTeamPage() {
                 {player.imageUrl && (
                   <img
                     src={player.imageUrl}
-                    alt={`${player.firstName} ${player.lastName}`}
+                    alt={formatName(player.firstName, player.lastName)}
                     className="w-full h-48 object-contain bg-gray-100"
                   />
                 )}
                 <CardContent className="p-4 bg-gradient-to-r from-green-700 to-green-600 text-white">
                   <div className="flex flex-col">
                     <span className="text-xl font-semibold">
-                      {player.firstName} {player.lastName}
+                      {formatName(player.firstName, player.lastName)}
                     </span>
                     {player.age !== undefined && (
                       <span className="text-sm text-gray-200">{player.age} нас</span>

--- a/client/src/pages/news-detail.tsx
+++ b/client/src/pages/news-detail.tsx
@@ -3,7 +3,7 @@ import { useToast } from "@/hooks/use-toast";
 import { useQuery, useMutation } from "@tanstack/react-query";
 import { queryClient, apiRequest } from "@/lib/queryClient";
 import { isUnauthorizedError } from "@/lib/authUtils";
-import { getImageUrl } from "@/lib/utils";
+import { getImageUrl, formatName } from "@/lib/utils";
 import Navigation from "@/components/navigation";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
 import { Button } from "@/components/ui/button";
@@ -402,7 +402,7 @@ export default function NewsDetail() {
                         {article.author?.profileImageUrl ? (
                           <img
                             src={getImageUrl(article.author.profileImageUrl)}
-                            alt={`${article.author.firstName} ${article.author.lastName}`}
+                            alt={formatName(article.author.firstName, article.author.lastName)}
                             className="w-full h-full object-cover"
                             onError={(e) => {
                               console.error('Author profile image failed to load:', article.author?.profileImageUrl);
@@ -422,12 +422,12 @@ export default function NewsDetail() {
                           <User className="h-6 w-6 text-gray-400" />
                         )}
                         <figcaption className="sr-only">
-                          {article.author?.firstName} {article.author?.lastName}
+                          {formatName(article.author?.firstName, article.author?.lastName)}
                         </figcaption>
                       </div>
                       <div>
                         <p className="font-semibold text-gray-900">
-                          {article.author?.firstName} {article.author?.lastName}
+                          {formatName(article.author?.firstName, article.author?.lastName)}
                         </p>
                         <div className="flex items-center text-sm text-gray-500">
                           <Clock className="h-3 w-3 mr-1" />

--- a/client/src/pages/player-dashboard.tsx
+++ b/client/src/pages/player-dashboard.tsx
@@ -10,6 +10,7 @@ import { Progress } from "@/components/ui/progress";
 import { Separator } from "@/components/ui/separator";
 import { User, Trophy, Calendar, CreditCard, BarChart3, Target, TrendingUp, Award, Star } from "lucide-react";
 import { isUnauthorizedError } from "@/lib/authUtils";
+import { formatName } from "@/lib/utils";
 
 export default function PlayerDashboard() {
   const { user, isAuthenticated, isLoading } = useAuth();
@@ -131,7 +132,7 @@ export default function PlayerDashboard() {
                     </div>
                   )}
                   <div>
-                    <h3 className="text-xl font-bold">{user.firstName} {user.lastName}</h3>
+                    <h3 className="text-xl font-bold">{formatName(user.firstName, user.lastName)}</h3>
                     <p className="opacity-80">Тоглогч</p>
                     {player?.memberNumber && (
                       <p className="text-sm opacity-70">Гишүүн №: {player.memberNumber}</p>
@@ -329,8 +330,8 @@ export default function PlayerDashboard() {
                                     <div className="flex items-center text-sm text-gray-700">
                                       <span className="font-medium">vs</span>
                                       <span className="ml-2">
-                                        {match.opponent?.name || 
-                                         (match.opponent?.user ? `${match.opponent.user.firstName} ${match.opponent.user.lastName}` : 
+                                        {match.opponent?.name ||
+                                         (match.opponent?.user ? formatName(match.opponent.user.firstName, match.opponent.user.lastName) :
                                           'Харсагч олдсонгүй')}
                                       </span>
                                     </div>
@@ -404,7 +405,7 @@ export default function PlayerDashboard() {
                               >
                                 <div>
                                   <p className="font-medium text-gray-900">
-                                    vs {opponent?.user?.firstName} {opponent?.user?.lastName}
+                                    vs {formatName(opponent?.user?.firstName, opponent?.user?.lastName)}
                                   </p>
                                   <p className="text-sm text-gray-600">
                                     {match.scheduledAt 

--- a/client/src/pages/player-profile.tsx
+++ b/client/src/pages/player-profile.tsx
@@ -5,6 +5,7 @@ import { Button } from "@/components/ui/button";
 import { Badge } from "@/components/ui/badge";
 import { ArrowLeft, User, Trophy, Calendar, MapPin, Phone, Mail } from "lucide-react";
 import Navigation from "@/components/navigation";
+import { formatName } from "@/lib/utils";
 
 export default function PlayerProfilePage() {
   const [match, params] = useRoute("/player/:id");
@@ -105,7 +106,7 @@ export default function PlayerProfilePage() {
                       <User className="h-12 w-12" />
                     </div>
                   )}
-                  <h2 className="text-2xl font-bold">{user?.firstName} {user?.lastName}</h2>
+                  <h2 className="text-2xl font-bold">{formatName(user?.firstName, user?.lastName)}</h2>
                   <p className="opacity-80">Тоглогч</p>
                   {player?.memberNumber && (
                     <p className="text-sm opacity-70 mt-1">Гишүүн №: {player.memberNumber}</p>
@@ -186,8 +187,8 @@ export default function PlayerProfilePage() {
                           {tournamentMatches.map((match: any, index: number) => {
                             const isWinner = match.isWinner;
                             const hasResult = match.result && match.result.trim() !== '';
-                            const opponentName = match.opponent?.name || 
-                                                (match.opponent?.user ? `${match.opponent.user.firstName} ${match.opponent.user.lastName}` : 
+                            const opponentName = match.opponent?.name ||
+                                                (match.opponent?.user ? formatName(match.opponent.user.firstName, match.opponent.user.lastName) :
                                                  'Харсагч олдсонгүй');
                             
                             // Parse score from result (assuming format like "3-1" or "2:3")
@@ -246,7 +247,7 @@ export default function PlayerProfilePage() {
                                           onClick={() => navigate(`/player-profile/${params?.id}`)}
                                           className="text-lg font-semibold text-blue-600 hover:text-blue-800 hover:underline cursor-pointer"
                                         >
-                                          {player?.firstName} {player?.lastName}
+                                          {formatName(player?.firstName, player?.lastName)}
                                         </button>
                                       </div>
                                       
@@ -296,7 +297,7 @@ export default function PlayerProfilePage() {
                             const isPlayer1 = match.player1Id === params?.id;
                             const isWinner = match.winnerId === params?.id;
                             const opponent = isPlayer1 ? match.player2 : match.player1;
-                            const opponentName = opponent?.user ? `${opponent.user.firstName} ${opponent.user.lastName}` : 'Харсагч олдсонгүй';
+                            const opponentName = opponent?.user ? formatName(opponent.user.firstName, opponent.user.lastName) : 'Харсагч олдсонгүй';
                             
                             // Calculate total score from sets
                             let playerTotalScore = 0;
@@ -356,7 +357,7 @@ export default function PlayerProfilePage() {
                                           onClick={() => navigate(`/player-profile/${params?.id}`)}
                                           className="text-lg font-semibold text-blue-600 hover:text-blue-800 hover:underline cursor-pointer"
                                         >
-                                          {player?.firstName} {player?.lastName}
+                                          {formatName(player?.firstName, player?.lastName)}
                                         </button>
                                       </div>
                                       

--- a/client/src/pages/profile.tsx
+++ b/client/src/pages/profile.tsx
@@ -18,6 +18,7 @@ import { AlertCircle, CheckCircle, Clock, User, Camera, MapPin, Phone, Mail, Cal
 import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { apiRequest } from "@/lib/queryClient";
 import { useTheme } from "@/contexts/ThemeContext";
+import { formatName } from "@/lib/utils";
 
 interface PlayerStats {
   rank?: string;
@@ -408,13 +409,13 @@ export default function Profile() {
                   <Avatar className="w-24 h-24">
                     <AvatarImage src={profile?.profilePicture} alt={profile?.firstName} />
                     <AvatarFallback className="text-2xl">
-                      {(profile?.firstName?.[0] || '') + (profile?.lastName?.[0] || '')}
+                      {(profile?.lastName?.[0] || '') + (profile?.firstName?.[0] || '')}
                     </AvatarFallback>
                   </Avatar>
                 </div>
                 <div className="text-center md:text-left flex-1">
                   <div className="flex items-center gap-3 flex-wrap">
-                    <h1 className="text-3xl font-bold theme-text">{profile?.firstName} {profile?.lastName}</h1>
+                    <h1 className="text-3xl font-bold theme-text">{formatName(profile?.firstName, profile?.lastName)}</h1>
                     {/* Tournament Medals */}
                     {medals && medals.map((medal: any) => (
                       <div key={`${medal.tournamentId}-${medal.medalType}`} className={`flex items-center gap-1 px-2 py-1 rounded-full text-xs font-medium ${

--- a/client/src/pages/tournament-page.tsx
+++ b/client/src/pages/tournament-page.tsx
@@ -16,6 +16,7 @@ import { useQuery, useMutation, useQueryClient } from "@tanstack/react-query";
 import { format } from "date-fns";
 import Navigation from "@/components/navigation";
 import PageWithLoading from "@/components/PageWithLoading";
+import { formatName } from "@/lib/utils";
 
 interface Tournament {
   id: string;
@@ -349,7 +350,7 @@ function TournamentParticipants({ tournamentId }: { tournamentId: string }) {
   const filteredParticipants = useMemo(() => {
     return participants.filter(participant => {
       const matchesSearch = searchTerm === "" || 
-        `${participant.firstName} ${participant.lastName}`.toLowerCase().includes(searchTerm.toLowerCase()) ||
+        formatName(participant.firstName, participant.lastName).toLowerCase().includes(searchTerm.toLowerCase()) ||
         participant.clubAffiliation?.toLowerCase().includes(searchTerm.toLowerCase());
       
       const matchesClub = clubFilter === "all" || participant.clubAffiliation === clubFilter;
@@ -444,7 +445,7 @@ function TournamentParticipants({ tournamentId }: { tournamentId: string }) {
                       }}
                     >
                       <User className="w-4 h-4" />
-                      {participant.firstName} {participant.lastName}
+                      {formatName(participant.firstName, participant.lastName)}
                     </button>
                   </TableCell>
                   <TableCell className="text-gray-300">{participant.clubAffiliation || "Тодорхойгүй"}</TableCell>


### PR DESCRIPTION
## Summary
- add reusable `formatName` util to swap surname and given name order
- show surname before given name across player-related pages and components

## Testing
- `npm test` *(fails: Missing script)*
- `npm run check` *(fails: Property 'fullName' does not exist on type)*

------
https://chatgpt.com/codex/tasks/task_e_68c2324983348321a597514df0858437