### PR TITLE
Fix tournament publishing and button feedback

### DIFF
--- a/server/routes.ts
+++ b/server/routes.ts
@@ -979,7 +979,11 @@ export async function registerRoutes(app: Express): Promise<Server> {
         contactInfo: req.body.contactInfo || null,
         schedule: req.body.schedule || null,
         requirements: req.body.requirements || null,
-        isPublished: req.body.isPublished || false,
+        // Ensure we always store a proper boolean value
+        // This avoids cases where "isPublished" might come through as a string
+        // like "true" or "false" which would otherwise be treated as truthy
+        // when using the `||` operator above.
+        isPublished: Boolean(req.body.isPublished),
         organizerId: req.session.userId,
         clubId: null,
         backgroundImageUrl: req.body.backgroundImageUrl || null,


### PR DESCRIPTION
## Summary
- Ensure tournament creation correctly parses `isPublished` as a boolean
- Add optimistic update and `apiRequest` for admin publish toggle button for instant color change

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run check`


------
https://chatgpt.com/codex/tasks/task_e_68c817eec4ec8321b21c273592d7b5a1