### PR TITLE
Prefill tournament data in admin edit dialog

### DIFF
--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -407,6 +407,18 @@ const { data: judges, isLoading: judgesLoading, refetch: judgesRefetch } = useQu
         ownerName: item.ownerName || "",
         extraData: item.extraData || [],
       });
+    } else if (selectedTab === "tournaments") {
+      setFormData({
+        name: item.name || "",
+        description: item.description || "",
+        startDate: item.startDate ? item.startDate.split('T')[0] : "",
+        endDate: item.endDate ? item.endDate.split('T')[0] : "",
+        location: item.location || "",
+        maxParticipants: item.maxParticipants || "",
+        entryFee: item.entryFee || "",
+        status: item.status || "",
+        isPublished: item.isPublished || false,
+      });
     } else if (selectedTab === "judges") {
       setFormData({
         firstName: item.firstName || "",


### PR DESCRIPTION
## Summary
- Populate admin tournament edit dialog with existing values so fields are pre-filled when editing

## Testing
- `npm run check` *(fails: TS errors in server/routes.ts and storage.ts)*

------
https://chatgpt.com/codex/tasks/task_e_68c820f9e0f083219838765a29a4f9ed