### PR TITLE
Expand tournament edit dialog

### DIFF
--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -3558,7 +3558,9 @@ const { data: judges, isLoading: judgesLoading, refetch: judgesRefetch } = useQu
         setEditingItem(null);
         setFormData({}); // Reset form data on close
       }}>
-        <DialogContent className="max-w-4xl max-h-[90vh] overflow-y-auto">
+        <DialogContent
+          className={`${selectedTab === 'tournaments' ? 'max-w-[90vw] max-h-[95vh]' : 'max-w-4xl max-h-[90vh]'} overflow-y-auto`}
+        >
           <DialogHeader>
             <DialogTitle>
               {selectedTab === 'users' ? 'Хэрэглэгч засах' :


### PR DESCRIPTION
## Summary
- expand tournament edit dialog to near-full viewport width and height so all details are visible

## Testing
- `npm run check` *(fails: TS errors in server routes)*
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68c8242aa9d48321bf5f551cb7987bf0