### PR TITLE
Fix header menu visibility in light mode

### DIFF
--- a/client/src/components/navigation.tsx
+++ b/client/src/components/navigation.tsx
@@ -224,7 +224,7 @@ export default function Navigation() {
                   variant="ghost"
                   size="icon"
                   onClick={() => setShowSearch(true)}
-                  className="h-9 w-9 text-white hover:text-green-300"
+                  className="h-9 w-9 text-slate-900 hover:text-green-600 dark:text-white dark:hover:text-green-300"
                   data-testid="search-toggle"
                   title="Search"
                 >
@@ -236,7 +236,7 @@ export default function Navigation() {
                   ref={triggerRef}
                   variant="ghost"
                   size="sm"
-                  className="lg:hidden text-white hover:text-mtta-green p-2"
+                  className="lg:hidden p-2 text-slate-900 hover:text-mtta-green dark:text-white"
                   onClick={() => setShowMobileMenu((v) => !v)}
                   data-testid="mobile-menu-toggle"
                 >

--- a/client/src/index.css
+++ b/client/src/index.css
@@ -1281,7 +1281,7 @@ label {
 
 /* Navigation link enhancements */
 .nav-link {
-  color: #ffffff !important;
+  color: inherit !important;
   font-size: 0.875rem;
   font-weight: 500;
   letter-spacing: 0.025em;
@@ -1294,9 +1294,29 @@ label {
   white-space: nowrap;
 }
 
+.nav-dark .nav-link {
+  color: #f8fafc !important;
+}
+
+[data-theme="light"] .nav-dark .nav-link,
+.light .nav-dark .nav-link {
+  color: #0f172a !important;
+}
+
 .nav-link:hover {
   color: var(--link) !important;
   background: rgba(255, 255, 255, 0.05) !important;
+}
+
+[data-theme="light"] .nav-dark .nav-link:hover,
+.light .nav-dark .nav-link:hover {
+  background: rgba(15, 23, 42, 0.05) !important;
+}
+
+[data-theme="light"] .nav-dark .active-nav-link,
+.light .nav-dark .active-nav-link {
+  color: var(--link) !important;
+  background: rgba(var(--link-rgb), 0.15) !important;
 }
 
 /* Active state for nav links */


### PR DESCRIPTION
## Summary
- update navigation link styles to respect theme colors and ensure light mode contrast
- adjust header icon buttons so their colors respond to the active theme

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_e_68d39ab9c6248321afb44c3f85b96d5a