### PR TITLE
Allow admins to view rank change proof images

### DIFF
--- a/client/src/pages/admin-dashboard.tsx
+++ b/client/src/pages/admin-dashboard.tsx
@@ -4062,22 +4062,8 @@ const { data: judges, isLoading: judgesLoading, refetch: judgesRefetch } = useQu
                                     variant="outline"
                                     size="sm"
                                     onClick={() => {
-                                      let imageUrl = request.proofImageUrl;
-                                      
-                                      if (!imageUrl.startsWith('http')) {
-                                        // Remove leading slash if present
-                                        const cleanPath = imageUrl.replace(/^\/+/, '');
-                                        
-                                        // If it already starts with objects/, use as is
-                                        if (cleanPath.startsWith('objects/')) {
-                                          imageUrl = `/${cleanPath}`;
-                                        } else {
-                                          // Otherwise add objects/ prefix
-                                          imageUrl = `/objects/${cleanPath}`;
-                                        }
-                                      }
-                                      
-                                      setSelectedImageUrl(imageUrl);
+                                      const normalizedUrl = getImageUrl(request.proofImageUrl);
+                                      setSelectedImageUrl(normalizedUrl);
                                       setImageModalOpen(true);
                                     }}
                                     className="flex items-center gap-2"


### PR DESCRIPTION
## Summary
- normalize rank proof image URLs in the admin dashboard by reusing the shared helper
- allow administrator sessions to bypass ACL checks when downloading private objects so proofs load

## Testing
- npm run check *(fails: existing TypeScript errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d39d9cafc883219d197952b280bd1b