### PR TITLE
Add global search support across site content

### DIFF
--- a/client/src/pages/clubs.tsx
+++ b/client/src/pages/clubs.tsx
@@ -41,7 +41,11 @@ function getImageUrl(imageUrl?: string): string {
 }
 
 export default function Clubs() {
-  const [searchQuery, setSearchQuery] = useState("");
+  const [searchQuery, setSearchQuery] = useState(() => {
+    if (typeof window === "undefined") return "";
+    const params = new URLSearchParams(window.location.search);
+    return params.get("q") || "";
+  });
 
   // Fetch clubs from database
   const { data: allClubs = [], isLoading, error } = useQuery({

--- a/client/src/pages/judges.tsx
+++ b/client/src/pages/judges.tsx
@@ -1,4 +1,4 @@
-import { useState } from "react";
+import { useEffect, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import Navigation from "@/components/navigation";
 import PageWithLoading from "@/components/PageWithLoading";
@@ -15,7 +15,20 @@ interface Judge {
 }
 
 export default function JudgesPage() {
-  const [tab, setTab] = useState("domestic");
+  const [tab, setTab] = useState(() => {
+    if (typeof window === "undefined") return "domestic";
+    const params = new URLSearchParams(window.location.search);
+    const type = params.get("type");
+    return type === "international" ? "international" : "domestic";
+  });
+
+  useEffect(() => {
+    if (typeof window === "undefined") return;
+    const params = new URLSearchParams(window.location.search);
+    params.set("type", tab);
+    const newUrl = `${window.location.pathname}?${params.toString()}`;
+    window.history.replaceState(null, "", newUrl);
+  }, [tab]);
 
   const {
     data: judges,

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -1058,6 +1058,36 @@ export async function registerRoutes(app: Express): Promise<Server> {
   });
 
   // --------------
+  // Global Search
+  // --------------
+  app.get("/api/search", async (req, res) => {
+    try {
+      const query = typeof req.query.q === "string" ? req.query.q : "";
+      const limitParam = typeof req.query.limit === "string" ? parseInt(req.query.limit, 10) : undefined;
+      const limit = Number.isFinite(limitParam) && limitParam && limitParam > 0 ? Math.min(limitParam, 25) : 5;
+
+      if (query.trim().length < 2) {
+        return res.json({
+          players: [],
+          tournaments: [],
+          news: [],
+          clubs: [],
+          branches: [],
+          federationMembers: [],
+          judges: [],
+          nationalTeamPlayers: [],
+        });
+      }
+
+      const results = await storage.searchSiteContent(query, limit);
+      res.json(results);
+    } catch (e) {
+      console.error("Error performing global search:", e);
+      res.status(500).json({ message: "Хайлт хийхэд алдаа гарлаа" });
+    }
+  });
+
+  // --------------
   // Clubs / Branches / Federation members / Judges
   // --------------
   app.post("/api/clubs", requireAuth, async (req: any, res) => {


### PR DESCRIPTION
## Summary
- add a storage-level global search that aggregates players, tournaments, news, clubs, branches, federation members, judges, and national team players
- expose the new global search endpoint and hook the navigation command palette to fetch and render grouped results with contextual navigation
- allow deep links from search results by hydrating clubs and judges pages from URL query parameters

## Testing
- npm run check *(fails: existing project-wide TypeScript errors unrelated to this change)*

------
https://chatgpt.com/codex/tasks/task_e_68d3b69fc31483219e61b8b68fad68ca