### PR TITLE
feat: redesign judges council page

### DIFF
--- a/client/src/components/PageWithLoading.tsx
+++ b/client/src/components/PageWithLoading.tsx
@@ -1,30 +1,50 @@
-import React from 'react';
-import { usePageTransition } from '@/hooks/usePageTransition';
-import LoadingAnimation from '@/components/LoadingAnimation';
+import React from "react";
+import { usePageTransition } from "@/hooks/usePageTransition";
+import LoadingAnimation from "@/components/LoadingAnimation";
 
 interface PageWithLoadingProps {
   children: React.ReactNode;
+  isLoading?: boolean;
+  error?: unknown;
+  fallback?: React.ReactNode;
 }
 
-const PageWithLoading: React.FC<PageWithLoadingProps> = ({ 
-  children
+const PageWithLoading: React.FC<PageWithLoadingProps> = ({
+  children,
+  isLoading,
+  error,
+  fallback,
 }) => {
-  const { isLoading } = usePageTransition();
+  const { isLoading: transitionLoading } = usePageTransition();
+  const showLoading = typeof isLoading === "boolean" ? isLoading || transitionLoading : transitionLoading;
 
-  if (isLoading) {
+  if (error) {
     return (
-      <div className="min-h-screen main-bg flex items-center justify-center">
-        <div className="text-center">
-          <LoadingAnimation size={120} />
-          <p className="text-white text-xl mt-8 opacity-75">
-            Уншиж байна...
+      <div className="main-bg flex min-h-screen items-center justify-center px-4">
+        <div className="max-w-md rounded-2xl border border-emerald-500/20 bg-emerald-950/80 p-8 text-center text-white shadow-xl">
+          <h2 className="text-2xl font-semibold">Мэдээлэл авахад алдаа гарлаа</h2>
+          <p className="mt-3 text-sm text-emerald-100/80">
+            Түр хүлээгээд дахин оролдоно уу. Хэрэв асуудал үргэлжилбэл системийн администраторт мэдэгдэнэ үү.
           </p>
         </div>
       </div>
     );
   }
 
-  return <div className="min-h-screen main-bg">{children}</div>;
+  if (showLoading) {
+    return (
+      <div className="main-bg flex min-h-screen items-center justify-center">
+        {fallback ?? (
+          <div className="text-center">
+            <LoadingAnimation size={120} />
+            <p className="mt-8 text-xl text-white opacity-75">Уншиж байна...</p>
+          </div>
+        )}
+      </div>
+    );
+  }
+
+  return <div className="main-bg min-h-screen">{children}</div>;
 };
 
 export default PageWithLoading;

--- a/client/src/components/council/CouncilHero.tsx
+++ b/client/src/components/council/CouncilHero.tsx
@@ -1,0 +1,42 @@
+interface CouncilHeroProps {
+  title: string;
+  subtitle?: string;
+  backgroundImage?: string;
+  overlayClassName?: string;
+}
+
+export function CouncilHero({
+  title,
+  subtitle,
+  backgroundImage =
+    "https://images.unsplash.com/photo-1521737604893-d14cc237f11d?auto=format&fit=crop&w=1600&q=80",
+  overlayClassName,
+}: CouncilHeroProps) {
+  return (
+    <section className="relative h-[60vh] min-h-[360px] overflow-hidden">
+      <div
+        className="absolute inset-0 bg-cover bg-center"
+        style={{ backgroundImage: `url(${backgroundImage})` }}
+        aria-hidden="true"
+      />
+      <div
+        className={`absolute inset-0 bg-gradient-to-b from-emerald-950/85 via-emerald-900/75 to-emerald-950/90 ${
+          overlayClassName ?? ""
+        }`}
+        aria-hidden="true"
+      />
+      <div className="relative h-full flex items-center justify-center px-6">
+        <div className="text-center space-y-4 max-w-3xl">
+          <h1 className="text-4xl sm:text-5xl font-bold text-emerald-50 tracking-wide">
+            {title}
+          </h1>
+          {subtitle ? (
+            <p className="text-emerald-200 text-base sm:text-lg leading-relaxed">
+              {subtitle}
+            </p>
+          ) : null}
+        </div>
+      </div>
+    </section>
+  );
+}

--- a/client/src/components/council/CouncilMemberCard.tsx
+++ b/client/src/components/council/CouncilMemberCard.tsx
@@ -1,0 +1,127 @@
+import { motion } from "framer-motion";
+import { useMemo, useState } from "react";
+import { cn } from "@/lib/utils";
+
+interface CouncilMemberCardProps {
+  imageUrl?: string | null;
+  name: string;
+  role?: string;
+  status?: string;
+  description?: string | null;
+  highlight?: boolean;
+}
+
+function MemberImage({ imageUrl, name }: { imageUrl?: string | null; name: string }) {
+  const [didError, setDidError] = useState(false);
+  const initials = useMemo(() => {
+    return name
+      .split(" ")
+      .map((part) => part[0])
+      .filter(Boolean)
+      .join("")
+      .slice(0, 2)
+      .toUpperCase();
+  }, [name]);
+
+  if (!imageUrl || didError) {
+    return (
+      <div className="flex h-full w-full items-center justify-center bg-gradient-to-br from-emerald-800 via-emerald-900 to-emerald-950 text-3xl font-semibold text-emerald-100">
+        {initials || "?"}
+      </div>
+    );
+  }
+
+  return (
+    <img
+      src={imageUrl}
+      alt={name}
+      className="h-full w-full object-cover"
+      loading="lazy"
+      onError={() => setDidError(true)}
+    />
+  );
+}
+
+export function CouncilMemberCard({
+  imageUrl,
+  name,
+  role = "Шүүгчдийн Зөвлөлийн Гишүүн",
+  status,
+  description,
+  highlight = false,
+}: CouncilMemberCardProps) {
+  const [isFlipped, setIsFlipped] = useState(false);
+
+  return (
+    <motion.article
+      className="flex h-full flex-col"
+      whileHover={{ y: -8 }}
+      transition={{ duration: 0.3, ease: "easeOut" }}
+    >
+      <div
+        className="relative cursor-pointer"
+        style={{ perspective: "1200px" }}
+        onMouseEnter={() => setIsFlipped(true)}
+        onMouseLeave={() => setIsFlipped(false)}
+        onFocus={() => setIsFlipped(true)}
+        onBlur={() => setIsFlipped(false)}
+        tabIndex={0}
+      >
+        <motion.div
+          className="relative aspect-[3/4] w-full"
+          style={{ transformStyle: "preserve-3d" }}
+          animate={{ rotateY: isFlipped ? 180 : 0 }}
+          transition={{ duration: 0.6, ease: "easeInOut" }}
+        >
+          <div
+            className="absolute inset-0 overflow-hidden rounded-2xl"
+            style={{ backfaceVisibility: "hidden" }}
+          >
+            <div className="group relative h-full overflow-hidden bg-black">
+              <MemberImage imageUrl={imageUrl ?? undefined} name={name} />
+              <div className="absolute inset-0 bg-gradient-to-t from-emerald-950/95 via-emerald-700/30 to-transparent" />
+              <div className="absolute bottom-0 left-0 right-0 p-6">
+                <div className="relative inline-block">
+                  <p className="text-sm font-semibold uppercase tracking-wide text-emerald-100">
+                    {role}
+                  </p>
+                  <motion.div
+                    className="absolute bottom-0 left-0 h-0.5 bg-emerald-400"
+                    initial={{ width: 0 }}
+                    animate={{ width: isFlipped ? "100%" : 0 }}
+                    transition={{ duration: 0.4, ease: "easeInOut" }}
+                  />
+                </div>
+              </div>
+            </div>
+          </div>
+
+          <div
+            className="absolute inset-0 flex h-full w-full items-center justify-center rounded-2xl bg-gradient-to-br from-emerald-800 via-emerald-900 to-green-950 p-6"
+            style={{ backfaceVisibility: "hidden", transform: "rotateY(180deg)" }}
+          >
+            <div className="space-y-4 text-center">
+              <h3 className="text-lg font-semibold text-emerald-50">Танилцуулга</h3>
+              <p className="text-sm leading-relaxed text-emerald-100/90">
+                {description?.trim() || "Танилцуулга бэлтгэгдэж байна."}
+              </p>
+            </div>
+          </div>
+        </motion.div>
+      </div>
+
+      <motion.div
+        className={cn(
+          "mt-3 rounded-2xl border-2 border-emerald-500/20 bg-white p-6 text-left shadow-lg transition-colors duration-300",
+          highlight ? "border-emerald-400/60" : "hover:border-emerald-500/40"
+        )}
+        whileHover={{ backgroundColor: "#f0fdf4" }}
+        transition={{ duration: 0.3 }}
+      >
+        <h3 className="text-xl font-semibold text-emerald-900">{name}</h3>
+        {status ? <p className="text-sm text-emerald-700/70">{status}</p> : null}
+      </motion.div>
+    </motion.article>
+  );
+}
+

--- a/client/src/pages/judges.tsx
+++ b/client/src/pages/judges.tsx
@@ -1,18 +1,31 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import Navigation from "@/components/navigation";
 import PageWithLoading from "@/components/PageWithLoading";
 import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
-import { Card, CardContent } from "@/components/ui/card";
+import { CouncilHero } from "@/components/council/CouncilHero";
+import { CouncilMemberCard } from "@/components/council/CouncilMemberCard";
 import { formatName } from "@/lib/utils";
 
 interface Judge {
   id: string;
   firstName: string;
   lastName: string;
-  imageUrl?: string;
-  judgeType: string;
+  imageUrl?: string | null;
+  judgeType: "domestic" | "international" | string;
+  role?: string | null;
+  biography?: string | null;
 }
+
+const HERO_IMAGE =
+  "https://images.unsplash.com/photo-1758518729685-f88df7890776?auto=format&fit=crop&w=1600&q=80";
+const HERO_SUBTITLE =
+  "Монгол Улсын шүүхийн тогтолцоог төлөөлөн ажилладаг мэргэжлийн шүүгчдийн баг";
+
+const STATUS_LABEL: Record<string, string> = {
+  domestic: "Дотоодын шүүгч",
+  international: "Олон улсын шүүгч",
+};
 
 export default function JudgesPage() {
   const [tab, setTab] = useState(() => {
@@ -35,9 +48,12 @@ export default function JudgesPage() {
     isLoading: judgesLoading,
     error: judgesError,
   } = useQuery<Judge[]>({
-    queryKey: ["/api/judges", tab],
+    queryKey: ["judges", tab],
     queryFn: async () => {
       const res = await fetch(`/api/judges?type=${tab}`);
+      if (!res.ok) {
+        throw new Error("Шүүгчдийн мэдээллийг татахад алдаа гарлаа.");
+      }
       const data = await res.json();
       return Array.isArray(data) ? data : [];
     },
@@ -45,98 +61,77 @@ export default function JudgesPage() {
     refetchOnMount: true,
   });
 
-  const renderJudgeCard = (judge: Judge) => (
-    <Card key={judge.id} className="overflow-hidden">
-      {judge.imageUrl && (
-        <img
-          src={judge.imageUrl}
-          alt={formatName(judge.firstName, judge.lastName)}
-          className="w-full h-48 object-contain bg-gray-100"
-        />
-      )}
-      <CardContent className="p-4 bg-gradient-to-r from-green-700 to-green-600 text-white">
-        <div className="flex flex-col">
-          <span className="text-xl font-semibold">
-            {formatName(judge.firstName, judge.lastName)}
-          </span>
-          <span className="text-sm text-gray-200">
-            {judge.judgeType === "domestic" ? "Дотоодын шүүгч" : "Олон улсын шүүгч"}
-          </span>
-        </div>
-      </CardContent>
-    </Card>
-  );
-
-  console.log("Judges data:", { judges, judgesLoading, judgesError });
+  const filteredJudges = useMemo(() => {
+    if (!Array.isArray(judges)) return [];
+    return judges.filter((judge) => judge.judgeType === tab);
+  }, [judges, tab]);
 
   return (
     <PageWithLoading isLoading={judgesLoading} error={judgesError}>
       <Navigation />
-      <div className="main-bg">
-        <div className="container mx-auto px-4 py-8">
-          <h1 className="text-4xl font-bold text-white mb-6 text-center">
-            Шүүгчид
-          </h1>
-          <Tabs value={tab} onValueChange={setTab} className="w-full">
-            <TabsList className="grid w-full grid-cols-2 mb-6 bg-gray-800 border-gray-700">
-              <TabsTrigger
-                value="domestic"
-                className="data-[state=active]:bg-green-600 data-[state=active]:text-white"
-              >
-                Дотоодын шүүгчид
-              </TabsTrigger>
-              <TabsTrigger
-                value="international"
-                className="data-[state=active]:bg-green-600 data-[state=active]:text-white"
-              >
-                Олон улсын шүүгчид
-              </TabsTrigger>
-            </TabsList>
-            <TabsContent value="domestic">
-              <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-                {judges && Array.isArray(judges)
-                  ? judges
-                      .filter((judge) => judge.judgeType === "domestic")
-                      .map(renderJudgeCard)
-                  : null}
-                {judges &&
-                  Array.isArray(judges) &&
-                  judges.filter((judge) => judge.judgeType === "domestic").length === 0 && (
-                    <div className="col-span-full text-center text-gray-400 py-8">
-                      Дотоодын шүүгч байхгүй байна
-                    </div>
-                  )}
-                {!judges && (
-                  <div className="col-span-full text-center text-gray-400 py-8">
-                    Ачааллаж байна...
-                  </div>
-                )}
-              </div>
-            </TabsContent>
-            <TabsContent value="international">
-              <div className="grid gap-6 grid-cols-1 sm:grid-cols-2 md:grid-cols-3 lg:grid-cols-4">
-                {judges && Array.isArray(judges)
-                  ? judges
-                      .filter((judge) => judge.judgeType === "international")
-                      .map(renderJudgeCard)
-                  : null}
-                {judges &&
-                  Array.isArray(judges) &&
-                  judges.filter((judge) => judge.judgeType === "international").length === 0 && (
-                    <div className="col-span-full text-center text-gray-400 py-8">
-                      Олон улсын шүүгч байхгүй байна
-                    </div>
-                  )}
-                {!judges && (
-                  <div className="col-span-full text-center text-gray-400 py-8">
-                    Ачааллаж байна...
-                  </div>
-                )}
-              </div>
-            </TabsContent>
-          </Tabs>
-        </div>
+      <div className="bg-gradient-to-br from-emerald-950 via-emerald-900 to-green-950 text-emerald-50">
+        <CouncilHero title="Шүүгчдийн Зөвлөл" subtitle={HERO_SUBTITLE} backgroundImage={HERO_IMAGE} />
+        <section className="relative -mt-16 pb-20">
+          <div className="mx-auto max-w-7xl px-6">
+            <div className="rounded-3xl border border-emerald-500/20 bg-emerald-950/60 p-6 shadow-2xl backdrop-blur">
+              <Tabs value={tab} onValueChange={setTab} className="w-full">
+                <TabsList className="grid w-full grid-cols-2 gap-3 rounded-full bg-emerald-950/40 p-2">
+                  <TabsTrigger
+                    value="domestic"
+                    className="rounded-full border border-emerald-500/20 bg-emerald-900/40 px-6 py-3 text-sm font-semibold text-emerald-200 transition data-[state=active]:!border-transparent data-[state=active]:!bg-emerald-400 data-[state=active]:!text-emerald-950 data-[state=active]:shadow-lg"
+                  >
+                    Дотоодын шүүгчид
+                  </TabsTrigger>
+                  <TabsTrigger
+                    value="international"
+                    className="rounded-full border border-emerald-500/20 bg-emerald-900/40 px-6 py-3 text-sm font-semibold text-emerald-200 transition data-[state=active]:!border-transparent data-[state=active]:!bg-emerald-400 data-[state=active]:!text-emerald-950 data-[state=active]:shadow-lg"
+                  >
+                    Олон улсын шүүгчид
+                  </TabsTrigger>
+                </TabsList>
+                <TabsContent value="domestic" className="mt-8 focus-visible:outline-none">
+                  <JudgesGrid judges={filteredJudges} tab={tab} />
+                </TabsContent>
+                <TabsContent value="international" className="mt-8 focus-visible:outline-none">
+                  <JudgesGrid judges={filteredJudges} tab={tab} />
+                </TabsContent>
+              </Tabs>
+            </div>
+          </div>
+        </section>
       </div>
     </PageWithLoading>
+  );
+}
+
+function JudgesGrid({ judges, tab }: { judges: Judge[]; tab: string }) {
+  if (!judges.length) {
+    return (
+      <div className="rounded-2xl border border-emerald-500/20 bg-emerald-900/40 p-12 text-center text-emerald-200">
+        {tab === "domestic" ? "Дотоодын шүүгч байхгүй байна" : "Олон улсын шүүгч байхгүй байна"}
+      </div>
+    );
+  }
+
+  return (
+    <div className="grid grid-cols-1 gap-8 md:grid-cols-2 xl:grid-cols-3">
+      {judges.map((judge) => {
+        const name = formatName(judge.firstName, judge.lastName);
+        const status = STATUS_LABEL[judge.judgeType] ?? STATUS_LABEL[tab] ?? "";
+        const highlight = Boolean(judge.role?.toLowerCase().includes("дарга"));
+
+        return (
+          <CouncilMemberCard
+            key={judge.id}
+            imageUrl={judge.imageUrl}
+            name={name}
+            role={judge.role ?? "Шүүгчдийн Зөвлөлийн Гишүүн"}
+            status={status}
+            description={judge.biography}
+            highlight={highlight}
+          />
+        );
+      })}
+    </div>
   );
 }


### PR DESCRIPTION
## Summary
- add reusable council hero and member card components based on the provided Judges Council design
- extend the shared loading wrapper to support explicit loading and error states for API-backed pages
- rebuild the Judges Council page to use the new layout, hero, and animated member cards while preserving data fetching

## Testing
- npm run check *(fails: existing TypeScript errors in legacy history UI bundle and other unrelated modules)*

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_690dd23c081083218407ecf239657c15)